### PR TITLE
Traduz Dia 2, Dia 3 e puzzles para inglês + seleção de idioma

### DIFF
--- a/game/cenas/dia1/cenas/demissao.rpy
+++ b/game/cenas/dia1/cenas/demissao.rpy
@@ -13,7 +13,7 @@ label DEMISSAO:
 
     "*Sheppard fecha a porta*"
     python:
-        if config.language == "english":
+        if is_english():
             renpy.notify("Achievement - \"No Cash in Hand\" Case!")
         else:
             renpy.notify("Conquista - Caso da \"Mão Sem Grana\"!")

--- a/game/cenas/dia1/cenas/roles/ind_d.rpy
+++ b/game/cenas/dia1/cenas/roles/ind_d.rpy
@@ -66,7 +66,7 @@ label DIALOGO_HUGO_12_D:
     hugo "Uma delícia."
     hugo "Toma Thorn, você merece."
     python:
-        if config.language == "english":
+        if is_english():
             renpy.notify("Achievement - Thorn Snacks!")
         else:
             renpy.notify("Conquista - Biscoitos Thorn!")

--- a/game/cenas/dia2/cena21.rpy
+++ b/game/cenas/dia2/cena21.rpy
@@ -76,7 +76,7 @@ label CENA21:
 
     python:
         if(persistent.conquista_sheppard1 and persistent.conquista_sheppard2):
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Fate...")
             else:
                 renpy.notify("Conquista - Destino...")

--- a/game/cenas/dia2/cena23.rpy
+++ b/game/cenas/dia2/cena23.rpy
@@ -1,5 +1,16 @@
 label CENA23:
 
+    # Traduz os termos de parentesco ([ind_X_info[2]]/[3]) para o ingles quando
+    # o idioma ativo e o ingles. Feito em tempo de execucao para nao alterar o
+    # texto-fonte dos dialogos (o que invalidaria as traducoes ja existentes).
+    python:
+        if is_english():
+            _rel_pt_en = {"pai": "father", "tio": "uncle", "irmão": "brother", "irmã": "sister"}
+            for _info in (ind_a_info, ind_b_info, ind_c_info, ind_d_info):
+                if len(_info) >= 4:
+                    _info[2] = _rel_pt_en.get(_info[2], _info[2])
+                    _info[3] = _rel_pt_en.get(_info[3], _info[3])
+
     play music "audio/musicas/Pistas.mp3" fadein 2.0
 
     $flag_kamira = 0

--- a/game/lang.rpy
+++ b/game/lang.rpy
@@ -1,0 +1,75 @@
+## Seleção de idioma / Language selection ######################################
+##
+## Permite ao jogador escolher o idioma do jogo logo que ele é aberto pela
+## primeira vez. A escolha fica gravada nas preferências do Ren'Py (persistente
+## entre execuções), então esta tela só aparece uma vez. O idioma também pode
+## ser trocado depois, na tela de Preferências.
+##
+## Lets the player choose the game language the first time the game is opened.
+## The choice is stored in Ren'Py's preferences (persisted across launches), so
+## this screen only shows once. The language can also be changed later from the
+## Preferences screen.
+
+## Flag persistente que indica se o jogador já escolheu um idioma.
+default persistent.lang_chosen = False
+
+init python:
+
+    def is_english():
+        """Retorna True quando o idioma ativo e o ingles.
+
+        Usada no lugar de checar config.language diretamente para que os textos
+        embutidos no codigo (puzzles, notificacoes, etc.) acompanhem o idioma
+        escolhido em tempo de execucao."""
+        return _preferences.language == "english"
+
+
+## Tela de seleção de idioma exibida na abertura do jogo.
+screen language_select():
+
+    tag menu
+    modal True
+
+    add gui.main_menu_background
+    add Solid("#000000a0")
+
+    vbox:
+        align (0.5, 0.5)
+        spacing 30
+
+        text "Selecione o idioma\nSelect the language":
+            xalign 0.5
+            text_align 0.5
+            color gui.accent_color
+            size 40
+
+        null height 20
+
+        textbutton "Português":
+            xalign 0.5
+            text_size 32
+            action Return("none")
+
+        textbutton "English":
+            xalign 0.5
+            text_size 32
+            action Return("english")
+
+
+## Label de abertura: mostra a seleção de idioma apenas na primeira execução.
+label splashscreen:
+
+    if not persistent.lang_chosen:
+
+        call screen language_select
+
+        $ persistent.lang_chosen = True
+
+        if _return == "english":
+            $ _preferences.language = "english"
+        else:
+            $ _preferences.language = None
+
+        $ renpy.change_language(_preferences.language)
+
+    return

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -13,8 +13,10 @@
 ## The _() surrounding the string marks it as eligible for translation.
 
 define config.name = _("Cashand Case")
-#define config.language = "none"
-define config.language = "english"
+## Idioma padrão antes da escolha do jogador. None = idioma de origem
+## (Português). A escolha feita na tela inicial (lang.rpy) é gravada nas
+## preferências e restaurada automaticamente nas próximas execuções.
+define config.language = None
 
 ## Determines if the title given above is shown on the main menu screen. Set
 ## this to False to hide the title.

--- a/game/puzzles/dia1/app_dia01.rpy
+++ b/game/puzzles/dia1/app_dia01.rpy
@@ -8,7 +8,7 @@ label APP_DIA1:
         app_gabarito = []
         app_letras = []
 
-        if config.language == 'english':
+        if is_english():
             #inheritors
             app_resposta = ["_", "_", "_", "_", "_", "_", "_", "_", "_", "_"]
             app_pre_resposta = "The culprit is one of the..."

--- a/game/puzzles/dia1/lop_3x3_dia01.rpy
+++ b/game/puzzles/dia1/lop_3x3_dia01.rpy
@@ -57,7 +57,7 @@ label SUCESSO_LOP_3X3_DIA01:
     python:
         if lop_rapido:
             persistent.rapido1 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Fake Watch!")
             else:
                 renpy.notify("Conquista - Relógio Falso!")

--- a/game/puzzles/dia1/pac_dia01.rpy
+++ b/game/puzzles/dia1/pac_dia01.rpy
@@ -52,7 +52,7 @@ label CHAMA_TELA_PAC_DIA1:
     #Inicializa as variáveis necessárias
     python:
 
-        if config.language == "english":
+        if is_english():
             pac3_item_lenco[1] = "Mr. Sheppard's handkerchief. I miss him ..."
             pac2_item_papel[1] = "Torn paper. It was taken from... Kamira's mouth..."
             pac3_item_lenco_pelos[1] = "There is hair inside the handkerchief. Probably, it's from some animal..."
@@ -90,7 +90,7 @@ label FIM_TELA_PAC_DIA1:
         if(len(pac1_itens_no_inventario) == 2):
             #pegou apenas o relogio e a mancha
             persistent.pac1 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - A Matter of Time!")
             else:
                 renpy.notify("Conquista - Questão de Tempo!")
@@ -214,7 +214,7 @@ label PAC1_SELECIONA_ESTANTE:
         hide screen mostra_item with dissolve
         #hide sheppard onlayer screens with dissolve
         python:
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Collected Clue - Bloodstain!")
             else:
                 renpy.notify("Coletou Pista - Mancha de Sangue!")
@@ -251,7 +251,7 @@ label PAC1_SELECIONA_RELOGIO:
         hide screen mostra_item with dissolve
         #hide sheppard onlayer screens with dissolve
         python:
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Collected Clue - Watch!")
             else:
                 renpy.notify("Coletou Pista - Relógio!")
@@ -286,7 +286,7 @@ label PAC1_SELECIONA_LAPIS:
     "Vou levar, talvez me seja útil futuramente..."
     hide screen mostra_item with dissolve
     python:
-        if config.language == "english":
+        if is_english():
             renpy.notify("Collected Clue - Pencil!")
         else:
             renpy.notify("Coletou Pista - Lápis!")
@@ -321,7 +321,7 @@ label PAC1_SELECIONA_LIVROS:
         "Voltando à investigação..."
         hide screen mostra_item with dissolve
         python:
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Collected Clue - Books!")
             else:
                 renpy.notify("Coletou Pista - Livros!")
@@ -347,7 +347,7 @@ label PAC1_SELECIONA_CAMERA:
         "Devem ser bem ricos mesmo."
         hide screen mostra_item with dissolve
         python:
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Collected Clue - Camera!")
             else:
                 renpy.notify("Coletou Pista - Câmera!")

--- a/game/puzzles/dia2/lop_4x4_dia02.rpy
+++ b/game/puzzles/dia2/lop_4x4_dia02.rpy
@@ -55,7 +55,7 @@ label SUCESSO_LOP_4X4_DIA02:
     python:
         if lop_rapido:
             persistent.rapido4 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Luminous Password!")
             else:
                 renpy.notify("Conquista - Senha Luminosa!")

--- a/game/puzzles/dia2/pac_dia02.rpy
+++ b/game/puzzles/dia2/pac_dia02.rpy
@@ -26,7 +26,7 @@ label FIM_TELA_PAC_DIA2:
         if(len(pac1_itens_no_inventario) == 4):
             #pegou apenas o lenco, o lapis, o gravador e a tesoura
             persistent.pac2 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Recorded Truth!")
             else:
                 renpy.notify("Conquista - Verdade Gravada!")

--- a/game/puzzles/dia2/slp_dia02.rpy
+++ b/game/puzzles/dia2/slp_dia02.rpy
@@ -83,7 +83,7 @@ label SUCESSO_SLP_3X3_DIA02:
     python:
         if lop_rapido:
             persistent.rapido2 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - One Last Note...")
             else:
                 renpy.notify("Conquista - Uma Última Nota...")

--- a/game/puzzles/dia2/slp_dia02_2.rpy
+++ b/game/puzzles/dia2/slp_dia02_2.rpy
@@ -82,7 +82,7 @@ label SUCESSO_SLP_3X3_DIA02_2:
     python:
         if lop_rapido:
             persistent.rapido3 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - The Pencil and the Spring!")
             else:
                 renpy.notify("Conquista - O Lápis e a Mola!")

--- a/game/puzzles/dia3/pac_dia03.rpy
+++ b/game/puzzles/dia3/pac_dia03.rpy
@@ -47,7 +47,7 @@ label FIM_TELA_PAC_DIA3:
         if(len(pac1_itens_no_inventario) == 3):
             #pegou apenas o lenco, o cofre e a chave
             persistent.pac3 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Retained Past!")
             else:
                 renpy.notify("Conquista - Passado Guardado!")

--- a/game/puzzles/dia3/slp_dia03.rpy
+++ b/game/puzzles/dia3/slp_dia03.rpy
@@ -93,7 +93,7 @@ label SUCESSO_SLP_4X4_DIA03:
     python:
         if lop_rapido:
             persistent.rapido5 = True
-            if config.language == "english":
+            if is_english():
                 renpy.notify("Achievement - Symbolic Safe!")
             else:
                 renpy.notify("Conquista - Cofre Simbólico!")

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -774,6 +774,12 @@ screen preferences():
                     textbutton _("Após Escolhas") action Preference("after choices", "toggle")
                     textbutton _("Transições") action InvertSelected(Preference("transitions", "toggle"))
 
+                vbox:
+                    style_prefix "radio"
+                    label _("Idioma")
+                    textbutton "Português" action Language(None)
+                    textbutton "English" action Language("english")
+
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.
 

--- a/game/tl/english/cenas/dia2/cena21.rpy
+++ b/game/tl/english/cenas/dia2/cena21.rpy
@@ -4,197 +4,197 @@
 translate english CENA21_b34266b7:
 
     # mrth "Senhor Rightclue!"
-    mrth ""
+    mrth "Mr. Rightclue!"
 
 # game/cenas/dia2/cena21.rpy:19
 translate english CENA21_b34266b7_1:
 
     # mrth "Senhor Rightclue!"
-    mrth ""
+    mrth "Mr. Rightclue!"
 
 # game/cenas/dia2/cena21.rpy:21
 translate english CENA21_ddba3e76:
 
     # drc "Sim, Martha? São apenas três da manhã."
-    drc ""
+    drc "Yes, Martha? It's only three in the morning."
 
 # game/cenas/dia2/cena21.rpy:22
 translate english CENA21_e964dc7b:
 
     # mrth "É o Sheppard, senhor! Está morto no chão de seu quarto!"
-    mrth ""
+    mrth "It's Sheppard, sir! He's dead on the floor of his room!"
 
 # game/cenas/dia2/cena21.rpy:23
 translate english CENA21_df6767de:
 
     # mrth "Céus, venha depressa!"
-    mrth ""
+    mrth "Heavens, come quickly!"
 
 # game/cenas/dia2/cena21.rpy:24
 translate english CENA21_03f4af83:
 
     # drc "Não..."
-    drc ""
+    drc "No..."
 
 # game/cenas/dia2/cena21.rpy:29
 translate english CENA21_33a3afcf:
 
     # drc "Não. Não. Não."
-    drc ""
+    drc "No. No. No."
 
 # game/cenas/dia2/cena21.rpy:40
 translate english CENA21_f629e4f0:
 
     # drc "NÃO! NÃO! NÃO! NÃO! NÃO!"
-    drc ""
+    drc "NO! NO! NO! NO! NO!"
 
 # game/cenas/dia2/cena21.rpy:41
 translate english CENA21_03f4af83_1:
 
     # drc "Não..."
-    drc ""
+    drc "No..."
 
 # game/cenas/dia2/cena21.rpy:50
 translate english CENA21_52889da2:
 
     # drc "Não... Não..."
-    drc ""
+    drc "No... No..."
 
 # game/cenas/dia2/cena21.rpy:56
 translate english CENA21_5d936419:
 
     # drc "Sheppard.... Por quê? Por quê?"
-    drc ""
+    drc "Sheppard.... Why? Why?"
 
 # game/cenas/dia2/cena21.rpy:57
 translate english CENA21_381995ec:
 
     # drc "Por quê?!"
-    drc ""
+    drc "Why?!"
 
 # game/cenas/dia2/cena21.rpy:60
 translate english CENA21_63a1a9a5:
 
     # drc "Por que eu tomei aquela decisão de lhe contar?"
-    drc ""
+    drc "Why did I make that decision to tell him?"
 
 # game/cenas/dia2/cena21.rpy:61
 translate english CENA21_b9041326:
 
     # "Isso pode ter pressionado o assassino."
-    ""
+    "That may have pressured the murderer."
 
 # game/cenas/dia2/cena21.rpy:62
 translate english CENA21_443031ba:
 
     # "O Sheppard seria um aliado muito importante para mim, afinal de contas."
-    ""
+    "Sheppard would have been a very important ally to me, after all."
 
 # game/cenas/dia2/cena21.rpy:63
 translate english CENA21_21de4f05:
 
     # "Conhecia muito bem todos os suspeitos..."
-    ""
+    "He knew all the suspects very well..."
 
 # game/cenas/dia2/cena21.rpy:64
 translate english CENA21_85dccaa9:
 
     # drc "Me desculpe, Sheppard. Me desculpe..."
-    drc ""
+    drc "I'm sorry, Sheppard. I'm sorry..."
 
 # game/cenas/dia2/cena21.rpy:65
 translate english CENA21_4693a616:
 
     # drc "Não pude salvá-lo."
-    drc ""
+    drc "I couldn't save him."
 
 # game/cenas/dia2/cena21.rpy:68
 translate english CENA21_5f449fe0:
 
     # drc "Por que eu tomei aquela decisão de não lhe contar?"
-    drc ""
+    drc "Why did I make that decision not to tell him?"
 
 # game/cenas/dia2/cena21.rpy:69
 translate english CENA21_94e3b62f:
 
     # "Ele poderia ter ficado mais atento com os suspeitos."
-    ""
+    "He could have been more watchful of the suspects."
 
 # game/cenas/dia2/cena21.rpy:70
 translate english CENA21_b4d365d6:
 
     # "O assassino estava nesta casa, afinal."
-    ""
+    "The murderer was in this house, after all."
 
 # game/cenas/dia2/cena21.rpy:71
 translate english CENA21_9556a449:
 
     # "Ele deve ter pensado que eu contaria a qualquer momento..."
-    ""
+    "He must have thought I would tell at any moment..."
 
 # game/cenas/dia2/cena21.rpy:72
 translate english CENA21_2e3f4d81:
 
     # "O Sheppard seria um aliado muito importante..."
-    ""
+    "Sheppard would have been a very important ally..."
 
 # game/cenas/dia2/cena21.rpy:73
 translate english CENA21_85dccaa9_1:
 
     # drc "Me desculpe, Sheppard. Me desculpe..."
-    drc ""
+    drc "I'm sorry, Sheppard. I'm sorry..."
 
 # game/cenas/dia2/cena21.rpy:74
 translate english CENA21_4693a616_1:
 
     # drc "Não pude salvá-lo."
-    drc ""
+    drc "I couldn't save him."
 
 # game/cenas/dia2/cena21.rpy:82
 translate english CENA21_177d318d:
 
     # "Meu Deus. Meu Deus..."
-    ""
+    "My God. My God..."
 
 # game/cenas/dia2/cena21.rpy:83
 translate english CENA21_d2166386:
 
     # "Por quê?"
-    ""
+    "Why?"
 
 # game/cenas/dia2/cena21.rpy:84
 translate english CENA21_bd29ee2a:
 
     # "Ele segurava um lenço."
-    ""
+    "He was holding a handkerchief."
 
 # game/cenas/dia2/cena21.rpy:88
 translate english CENA21_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena21.rpy:92
 translate english CENA21_012e6e4e:
 
     # "Me desculpe, Sheppard..."
-    ""
+    "I'm sorry, Sheppard..."
 
 # game/cenas/dia2/cena21.rpy:93
 translate english CENA21_a3c9d0ed:
 
     # "Eu não cheguei a tempo."
-    ""
+    "I didn't arrive in time."
 
 # game/cenas/dia2/cena21.rpy:94
 translate english CENA21_ae2aa6be:
 
     # "Não cheguei..."
-    ""
+    "I didn't make it..."
 
 # game/cenas/dia2/cena21.rpy:95
 translate english CENA21_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 

--- a/game/tl/english/cenas/dia2/cena22.rpy
+++ b/game/tl/english/cenas/dia2/cena22.rpy
@@ -4,377 +4,377 @@
 translate english CENA22_c370008b:
 
     # "Como fomos parar nisso...?"
-    ""
+    "How did we end up like this...?"
 
 # game/cenas/dia2/cena22.rpy:9
 translate english CENA22_c2cf8bdc:
 
     # "Sheppard está morto."
-    ""
+    "Sheppard is dead."
 
 # game/cenas/dia2/cena22.rpy:10
 translate english CENA22_5eb32546:
 
     # "Foi morto dentro de minha investigação."
-    ""
+    "He was killed in the middle of my investigation."
 
 # game/cenas/dia2/cena22.rpy:11
 translate english CENA22_4bee6603:
 
     # "É tudo minha culpa... Se eu tivesse sido mais cauteloso..."
-    ""
+    "It's all my fault... If I had been more cautious..."
 
 # game/cenas/dia2/cena22.rpy:12
 translate english CENA22_7dd8587e:
 
     # "Por segurança, pediram que Martha e outros funcionários se retirassem do serviço por algum tempo."
-    ""
+    "For safety, they asked Martha and the other staff to step away from work for a while."
 
 # game/cenas/dia2/cena22.rpy:13
 translate english CENA22_bea221f9:
 
     # "Preciso ser rápido e descobrir quem está por trás de tudo isso."
-    ""
+    "I must be quick and find out who is behind all this."
 
 # game/cenas/dia2/cena22.rpy:17
 translate english CENA22_2e798675:
 
     # "*[ind_a_info[0]] se aproxima do senhor Rightclue*"
-    ""
+    "*[ind_a_info[0]] approaches Mr. Rightclue*"
 
 # game/cenas/dia2/cena22.rpy:18
 translate english CENA22_c7e7fa96:
 
     # ind_a "Senhor Rightclue."
-    ind_a ""
+    ind_a "Mr. Rightclue."
 
 # game/cenas/dia2/cena22.rpy:19
 translate english CENA22_35706b28:
 
     # "É [ind_a_info[0]], preciso me recompor."
-    ""
+    "It's [ind_a_info[0]], I need to pull myself together."
 
 # game/cenas/dia2/cena22.rpy:20
 translate english CENA22_f92d2faf:
 
     # drc "Olá, [ind_a_info[1]]. Meus pêsames pela perda. O senhor Sheppard realmente se importava com vocês."
-    drc ""
+    drc "Hello, [ind_a_info[1]]. My condolences for your loss. Mr. Sheppard truly cared about you all."
 
 # game/cenas/dia2/cena22.rpy:27
 translate english CENA22_968ea036:
 
     # ind_a "Sim, senhor Rightclue. Apesar de tudo, Sheppard era como um membro da família. Vou sentir sua falta."
-    ind_a ""
+    ind_a "Yes, Mr. Rightclue. Despite everything, Sheppard was like a member of the family. I will miss him."
 
 # game/cenas/dia2/cena22.rpy:28
 translate english CENA22_54f3aff1:
 
     # "*[ind_a_info[1]] enxuga uma lágrima*"
-    ""
+    "*[ind_a_info[1]] wipes away a tear*"
 
 # game/cenas/dia2/cena22.rpy:32
 translate english CENA22_599f2915:
 
     # drc "Dou minha palavra a você, [ind_a_info[1]]. Prometo achar o culpado por tudo isso."
-    drc ""
+    drc "I give you my word, [ind_a_info[1]]. I promise to find the one guilty for all of this."
 
 # game/cenas/dia2/cena22.rpy:33
 translate english CENA22_7778d232:
 
     # ind_a "Deixo em suas mãos, detetive."
-    ind_a ""
+    ind_a "I leave it in your hands, detective."
 
 # game/cenas/dia2/cena22.rpy:41
 translate english CENA22_71e1bc67:
 
     # "Se o responsável por isso pensa que sairá impune, juro por minha honra que não irá!"
-    ""
+    "If the one responsible for this thinks he'll get away with it, I swear on my honor he won't!"
 
 # game/cenas/dia2/cena22.rpy:42
 translate english CENA22_9e401929:
 
     # "Farei justiça pelo senhor Sheppard. O culpado será preso. Ajudarei os herdeiros a se livrarem desse traidor!"
-    ""
+    "I will bring justice for Mr. Sheppard. The culprit will be arrested. I will help the heirs rid themselves of this traitor!"
 
 # game/cenas/dia2/cena22.rpy:43
 translate english CENA22_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena22.rpy:44
 translate english CENA22_503e9226:
 
     # "Realmente como me foi dito. Como manda o costume da cidade, enterrarão o senhor Sheppard ainda agora de manhã."
-    ""
+    "Just as I was told. As the town's custom dictates, they will bury Mr. Sheppard this very morning."
 
 # game/cenas/dia2/cena22.rpy:45
 translate english CENA22_11bedf1c:
 
     # "Hmm..."
-    ""
+    "Hmm..."
 
 # game/cenas/dia2/cena22.rpy:46
 translate english CENA22_ba96f969:
 
     # "Joe Cashand não saiu por nem um segundo do lado do corpo do Senhor Sheppard."
-    ""
+    "Joe Cashand didn't leave Mr. Sheppard's body for even a second."
 
 # game/cenas/dia2/cena22.rpy:47
 translate english CENA22_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena22.rpy:48
 translate english CENA22_5a92af26:
 
     # "Algo me chama atenção..."
-    ""
+    "Something catches my attention..."
 
 # game/cenas/dia2/cena22.rpy:49
 translate english CENA22_d4aa1200:
 
     # "Preciso investigar mais sobre as relações dos herdeiros com cada membro da família."
-    ""
+    "I need to investigate more about the heirs' relationships with each member of the family."
 
 # game/cenas/dia2/cena22.rpy:50
 translate english CENA22_977bdecb:
 
     # "[ind_b_info[1]] se juntou a [ind_a_info[1]]."
-    ""
+    "[ind_b_info[1]] joined [ind_a_info[1]]."
 
 # game/cenas/dia2/cena22.rpy:51
 translate english CENA22_a20cefa7_2:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena22.rpy:52
 translate english CENA22_359d2c6f:
 
     # "Pararam. Irei até eles."
-    ""
+    "They've stopped. I'll go to them."
 
 # game/cenas/dia2/cena22.rpy:53
 translate english CENA22_7d28be0b:
 
     # "Não tenho necessariamen..."
-    ""
+    "I don't necessaril..."
 
 # game/cenas/dia2/cena22.rpy:55
 translate english CENA22_d40f1e75:
 
     # desconhecido "Senhor Rightclue, eu suponho?"
-    desconhecido ""
+    desconhecido "Mr. Rightclue, I presume?"
 
 # game/cenas/dia2/cena22.rpy:56
 translate english CENA22_a20cefa7_3:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena22.rpy:60
 translate english CENA22_afa1d355:
 
     # drc "Sim, exato. E qual seria sua graça, senhor?"
-    drc ""
+    drc "Yes, exactly. And what would your name be, sir?"
 
 # game/cenas/dia2/cena22.rpy:61
 translate english CENA22_13ec4b78:
 
     # desconhecido "Já me conhece, senhor Rightclue. Sugiro que se lembre rapidamente. E falemos baixo, sim?"
-    desconhecido ""
+    desconhecido "You already know me, Mr. Rightclue. I suggest you remember quickly. And let's keep our voices down, shall we?"
 
 # game/cenas/dia2/cena22.rpy:62
 translate english CENA22_89e786a4:
 
     # drc "Suponho, pela voz, que o senhor seja Carlo Venchinni."
-    drc ""
+    drc "I suppose, by your voice, that you are Carlo Venchinni."
 
 # game/cenas/dia2/cena22.rpy:63
 translate english CENA22_f54b0518:
 
     # vnc "Vejo que o senhor tem astúcia."
-    vnc ""
+    vnc "I see that you have wit."
 
 # game/cenas/dia2/cena22.rpy:64
 translate english CENA22_26940d37:
 
     # vnc "Senhor Rightclue, deixe-me dizer uma coisa..."
-    vnc ""
+    vnc "Mr. Rightclue, let me tell you something..."
 
 # game/cenas/dia2/cena22.rpy:65
 translate english CENA22_a90123d2:
 
     # vnc "Estou tão furioso que mataria todos esses malditos, um após um, ao saírem desse velório."
-    vnc ""
+    vnc "I'm so furious I would kill every one of these wretches, one after another, as they leave this wake."
 
 # game/cenas/dia2/cena22.rpy:66
 translate english CENA22_c4166a0d:
 
     # vnc "Detetive, eu tinha uma dívida com Sheppard, que agora nunca poderei pagar. Por mim, eliminaria, na dúvida, todos os herdeiros do velho que estão aqui."
-    vnc ""
+    vnc "Detective, I had a debt to Sheppard that I can now never repay. If it were up to me, I'd eliminate, just to be sure, every one of the old man's heirs who are here."
 
 # game/cenas/dia2/cena22.rpy:67
 translate english CENA22_d564cb74:
 
     # drc "..."
-    drc ""
+    drc "..."
 
 # game/cenas/dia2/cena22.rpy:68
 translate english CENA22_f4c36c13:
 
     # vnc "Porém, o Senhor Sheppard realmente tinha apreço por essa família. E confiava em você para resolver o caso."
-    vnc ""
+    vnc "However, Mr. Sheppard truly held this family dear. And he trusted you to solve the case."
 
 # game/cenas/dia2/cena22.rpy:69
 translate english CENA22_481f50a5:
 
     # vnc "Deixe-me dizer mais uma coisa..."
-    vnc ""
+    vnc "Let me tell you one more thing..."
 
 # game/cenas/dia2/cena22.rpy:70
 translate english CENA22_2abf8d96:
 
     # vnc "O senhor tem até o anoitecer de amanhã. Seu horário limite é oito da noite."
-    vnc ""
+    vnc "You have until nightfall tomorrow. Your deadline is eight o'clock at night."
 
 # game/cenas/dia2/cena22.rpy:71
 translate english CENA22_f450593e:
 
     # vnc "Se o senhor não me entregar o culpado até lá, matarei todos esses vermes."
-    vnc ""
+    vnc "If you don't hand me the culprit by then, I'll kill every one of these worms."
 
 # game/cenas/dia2/cena22.rpy:72
 translate english CENA22_68101e9a:
 
     # vnc "Um após um..."
-    vnc ""
+    vnc "One after another..."
 
 # game/cenas/dia2/cena22.rpy:73
 translate english CENA22_9f3a89df:
 
     # vnc "Sem nenhuma piedade."
-    vnc ""
+    vnc "Without any mercy."
 
 # game/cenas/dia2/cena22.rpy:74
 translate english CENA22_982e241d:
 
     # vnc "Não me importo em começar uma guerra entre as famílias. Vingarei Sheppard. E sugiro que o senhor se retire da casa até essa data e hora."
-    vnc ""
+    vnc "I don't mind starting a war between the families. I will avenge Sheppard. And I suggest you leave the house by that date and time."
 
 # game/cenas/dia2/cena22.rpy:75
 translate english CENA22_19266b12:
 
     # vnc "Fui claro?"
-    vnc ""
+    vnc "Have I made myself clear?"
 
 # game/cenas/dia2/cena22.rpy:76
 translate english CENA22_8c60338a:
 
     # drc "Perfeitamente, senhor."
-    drc ""
+    drc "Perfectly, sir."
 
 # game/cenas/dia2/cena22.rpy:77
 translate english CENA22_e167921b:
 
     # vnc "Perfeito. Você tem um trabalho a cumprir. Cumpra-o. Eu terei o meu. O destino desses desgraçados está em suas mãos."
-    vnc ""
+    vnc "Perfect. You have a job to do. Do it. I'll have mine. The fate of these wretches is in your hands."
 
 # game/cenas/dia2/cena22.rpy:78
 translate english CENA22_8a6b8f0c:
 
     # drc "Estou de acordo, Senhor Venchinni."
-    drc ""
+    drc "I agree, Mr. Venchinni."
 
 # game/cenas/dia2/cena22.rpy:79
 translate english CENA22_76d7f26a:
 
     # vnc "Ótimo. Que assim seja."
-    vnc ""
+    vnc "Good. So be it."
 
 # game/cenas/dia2/cena22.rpy:87
 translate english CENA22_47f8c723:
 
     # "Meu Deus... Tenho um fardo grande para carregar."
-    ""
+    "My God... I have a heavy burden to carry."
 
 # game/cenas/dia2/cena22.rpy:88
 translate english CENA22_a20cefa7_4:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena22.rpy:89
 translate english CENA22_3beaa05b:
 
     # "Hugo se foi."
-    ""
+    "Hugo is gone."
 
 # game/cenas/dia2/cena22.rpy:90
 translate english CENA22_e7a626ce:
 
     # "O tempo está correndo. Preciso me apressar. Hoje e amanhã serão cruciais."
-    ""
+    "Time is running out. I must hurry. Today and tomorrow will be crucial."
 
 # game/cenas/dia2/cena22.rpy:96
 translate english DIALOGO_PERSONAGENS_D2C2_657da26a:
 
     # hugo "É complicado, senhor detetive. Fiquei um bom tempo fora de casa por causa de meu pai."
-    hugo ""
+    hugo "It's complicated, mr. detective. I spent a long time away from home because of my father."
 
 # game/cenas/dia2/cena22.rpy:97
 translate english DIALOGO_PERSONAGENS_D2C2_741d2bd1:
 
     # hugo "Mas o senhor Sheppard sempre foi bom com todos nós."
-    hugo ""
+    hugo "But Mr. Sheppard was always good to all of us."
 
 # game/cenas/dia2/cena22.rpy:98
 translate english DIALOGO_PERSONAGENS_D2C2_cec5af43:
 
     # hugo "Até o Thorn sente sua falta."
-    hugo ""
+    hugo "Even Thorn misses him."
 
 # game/cenas/dia2/cena22.rpy:99
 translate english DIALOGO_PERSONAGENS_D2C2_a339eb04:
 
     # hugo "Mas, mesmo assim, ele me consola bastante."
-    hugo ""
+    hugo "But, even so, he comforts me a lot."
 
 # game/cenas/dia2/cena22.rpy:100
 translate english DIALOGO_PERSONAGENS_D2C2_044a9623:
 
     # hugo "Não é, Thorn?"
-    hugo ""
+    hugo "Isn't that right, Thorn?"
 
 # game/cenas/dia2/cena22.rpy:103
 translate english DIALOGO_PERSONAGENS_D2C2_60403907:
 
     # hugo "Vamos sentir sua falta..."
-    hugo ""
+    hugo "We'll miss you..."
 
 # game/cenas/dia2/cena22.rpy:104
 translate english DIALOGO_PERSONAGENS_D2C2_1de7d133:
 
     # drc "Tenho certeza disso, Hugo."
-    drc ""
+    drc "I'm sure of that, Hugo."
 
 # game/cenas/dia2/cena22.rpy:107
 translate english DIALOGO_PERSONAGENS_D2C2_5fe5ed7f:
 
     # cth "É uma situação muito triste. Sheppard era como um irmão para mim e para o Gin."
-    cth ""
+    cth "It's a very sad situation. Sheppard was like a brother to me and to Gin."
 
 # game/cenas/dia2/cena22.rpy:108
 translate english DIALOGO_PERSONAGENS_D2C2_8bd11712:
 
     # cth "Não consigo acreditar que ele foi envolvido nisso injustamente."
-    cth ""
+    cth "I can't believe he was unjustly dragged into this."
 
 # game/cenas/dia2/cena22.rpy:109
 translate english DIALOGO_PERSONAGENS_D2C2_d1b88652:
 
     # drc "Tenho ciência."
-    drc ""
+    drc "I'm aware."
 

--- a/game/tl/english/cenas/dia2/cena23.rpy
+++ b/game/tl/english/cenas/dia2/cena23.rpy
@@ -4,815 +4,815 @@
 translate english CENA23_e4716f5b:
 
     # "Certo..."
-    ""
+    "Right..."
 
 # game/cenas/dia2/cena23.rpy:12
 translate english CENA23_a172dccd:
 
     # "Preciso agir rápido e começar a investigar quem já chegou do enterro."
-    ""
+    "I must act quickly and start investigating those who have returned from the burial."
 
 # game/cenas/dia2/cena23.rpy:13
 translate english CENA23_5400c82d:
 
     # "Kamira T. Cashand está ali no jardim, [ind_a_info[1]] deu a volta pelos fundos e entrou na cozinha."
-    ""
+    "Kamira T. Cashand is over there in the garden, [ind_a_info[1]] went around the back and into the kitchen."
 
 # game/cenas/dia2/cena23.rpy:14
 translate english CENA23_5f8b14bb:
 
     # "[ind_b_info[1]] veio junto com [ind_a_info[1]] e foi para o hall. Só Joe Cashand que ainda não chegou."
-    ""
+    "[ind_b_info[1]] came along with [ind_a_info[1]] and went to the hall. Only Joe Cashand hasn't arrived yet."
 
 # game/cenas/dia2/cena23.rpy:15
 translate english CENA23_4c0bea08:
 
     # "Uma rápida olhada em volta..."
-    ""
+    "A quick look around..."
 
 # game/cenas/dia2/cena23.rpy:25
 translate english ESCOLHA_CONV_DIA2C3_af57bf57:
 
     # "Bom... acho que melhor começar com [ind_a_info[1]]."
-    ""
+    "Well... I think it's best to start with [ind_a_info[1]]."
 
 # game/cenas/dia2/cena23.rpy:26
 translate english ESCOLHA_CONV_DIA2C3_15ac1b81:
 
     # "Vou tentar me aproximar na cozinha."
-    ""
+    "I'll try to approach in the kitchen."
 
 # game/cenas/dia2/cena23.rpy:27
 translate english ESCOLHA_CONV_DIA2C3_c9473548:
 
     # "Talvez eu descubra algo..."
-    ""
+    "Maybe I'll find out something..."
 
 # game/cenas/dia2/cena23.rpy:37
 translate english ESCOLHA_CONV_DIA2C3_6b0b32be:
 
     # drc "Confie em mim, [ind_a_info[1]], acharei o culpado. Mas preciso de sua cooperação."
-    drc ""
+    drc "Trust me, [ind_a_info[1]], I will find the culprit. But I need your cooperation."
 
 # game/cenas/dia2/cena23.rpy:38
 translate english ESCOLHA_CONV_DIA2C3_9299e5ed:
 
     # drc "Me conte o que viu na noite em que seu [ind_a_info[2]] foi assassinado. Quem subiu ao quarto?"
-    drc ""
+    drc "Tell me what you saw the night your [ind_a_info[2]] was murdered. Who went up to the room?"
 
 # game/cenas/dia2/cena23.rpy:39
 translate english ESCOLHA_CONV_DIA2C3_488984b2:
 
     # ind_a "..."
-    ind_a ""
+    ind_a "..."
 
 # game/cenas/dia2/cena23.rpy:40
 translate english ESCOLHA_CONV_DIA2C3_518cde56:
 
     # ind_a "Pois bem. Naquela noite, me encontrei com todos na sala. Sheppard estava lá também."
-    ind_a ""
+    ind_a "Very well. That night, I met with everyone in the living room. Sheppard was there too."
 
 # game/cenas/dia2/cena23.rpy:41
 translate english ESCOLHA_CONV_DIA2C3_a598c4f2:
 
     # ind_a "Após várias garrafas de espumante, meu [ind_a_info[2]] subiu ao quarto. Não passava bem por suas complicações de saúde e ainda assim insistia em beber."
-    ind_a ""
+    ind_a "After several bottles of sparkling wine, my [ind_a_info[2]] went up to his room. He wasn't well due to his health complications and yet he insisted on drinking."
 
 # game/cenas/dia2/cena23.rpy:42
 translate english ESCOLHA_CONV_DIA2C3_ea97358c:
 
     # drc "Estamos indo bem. O que mais, [ind_a_info[1]]?"
-    drc ""
+    drc "We're doing well. What else, [ind_a_info[1]]?"
 
 # game/cenas/dia2/cena23.rpy:43
 translate english ESCOLHA_CONV_DIA2C3_18006a20:
 
     # ind_a "Após beber mais algumas taças, senti que precisava checar se ele estava bem."
-    ind_a ""
+    ind_a "After drinking a few more glasses, I felt I needed to check whether he was all right."
 
 # game/cenas/dia2/cena23.rpy:44
 translate english ESCOLHA_CONV_DIA2C3_8d0c731d:
 
     # ind_a "Foi então que subi ao quarto. Vi Kamira passando com lágrimas nos olhos. A segui de volta para baixo, e perguntei o que havia acontecido."
-    ind_a ""
+    ind_a "That's when I went up to the room. I saw Kamira walking by with tears in her eyes. I followed her back downstairs and asked what had happened."
 
 # game/cenas/dia2/cena23.rpy:45
 translate english ESCOLHA_CONV_DIA2C3_ab91a4c7:
 
     # drc "E o que ela disse?"
-    drc ""
+    drc "And what did she say?"
 
 # game/cenas/dia2/cena23.rpy:46
 translate english ESCOLHA_CONV_DIA2C3_092877c3:
 
     # ind_a "Disse que havia brigado com meu [ind_a_info[2]]."
-    ind_a ""
+    ind_a "She said she had argued with my [ind_a_info[2]]."
 
 # game/cenas/dia2/cena23.rpy:47
 translate english ESCOLHA_CONV_DIA2C3_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena23.rpy:48
 translate english ESCOLHA_CONV_DIA2C3_0a130ac8:
 
     # drc "Entendo."
-    drc ""
+    drc "I see."
 
 # game/cenas/dia2/cena23.rpy:49
 translate english ESCOLHA_CONV_DIA2C3_39abaab2:
 
     # drc "Não tem mais nada que queira me contar?"
-    drc ""
+    drc "Is there nothing else you'd like to tell me?"
 
 # game/cenas/dia2/cena23.rpy:50
 translate english ESCOLHA_CONV_DIA2C3_0a99025a:
 
     # ind_a "O senhor tem minha palavra. Desta hora, até o momento da morte, não notei mais nada de suspeito."
-    ind_a ""
+    ind_a "You have my word. From that time until the moment of death, I noticed nothing else suspicious."
 
 # game/cenas/dia2/cena23.rpy:51
 translate english ESCOLHA_CONV_DIA2C3_0a130ac8_1:
 
     # drc "Entendo."
-    drc ""
+    drc "I see."
 
 # game/cenas/dia2/cena23.rpy:52
 translate english ESCOLHA_CONV_DIA2C3_d0a4871d:
 
     # drc "Mais uma coisa..."
-    drc ""
+    drc "One more thing..."
 
 # game/cenas/dia2/cena23.rpy:53
 translate english ESCOLHA_CONV_DIA2C3_1ae064be:
 
     # drc "Pode me contar como era o senhor Sheppard? Digo, no dia a dia da família."
-    drc ""
+    drc "Can you tell me what Mr. Sheppard was like? I mean, in the family's daily life."
 
 # game/cenas/dia2/cena23.rpy:54
 translate english ESCOLHA_CONV_DIA2C3_be01bec9:
 
     # ind_a "Sheppard era da família. Sempre foi considerado assim por todos nós."
-    ind_a ""
+    ind_a "Sheppard was family. He was always regarded that way by all of us."
 
 # game/cenas/dia2/cena23.rpy:55
 translate english ESCOLHA_CONV_DIA2C3_d33e304a:
 
     # ind_a "Sou nesse momento, uma pessoa horrorizada por tudo isso... Meu [ind_a_info[2]], meu [ind_a_info[3]] e agora Sheppard."
-    ind_a ""
+    ind_a "Right now, I am a person horrified by all of this... My [ind_a_info[2]], my [ind_a_info[3]] and now Sheppard."
 
 # game/cenas/dia2/cena23.rpy:56
 translate english ESCOLHA_CONV_DIA2C3_6d3cccca:
 
     # drc "Compreendo."
-    drc ""
+    drc "I understand."
 
 # game/cenas/dia2/cena23.rpy:57
 translate english ESCOLHA_CONV_DIA2C3_855ab814:
 
     # drc "Certo... Acho que já é suficiente por agora. Até mais, [ind_a_info[1]]."
-    drc ""
+    drc "Right... I think that's enough for now. See you, [ind_a_info[1]]."
 
 # game/cenas/dia2/cena23.rpy:62
 translate english ESCOLHA_CONV_DIA2C3_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena23.rpy:63
 translate english ESCOLHA_CONV_DIA2C3_537a7b27:
 
     # "Certo, já tenho um destino."
-    ""
+    "Right, I have somewhere to go now."
 
 # game/cenas/dia2/cena23.rpy:81
 translate english ESCOLHA_CONV_DIA2C3_205192d2:
 
     # "Tentarei com [ind_b_info[1]], no Hall. Talvez eu consiga ligar as coisas obtendo detalhes de cada um."
-    ""
+    "I'll try [ind_b_info[1]], in the Hall. Maybe I can connect things by getting details from each of them."
 
 # game/cenas/dia2/cena23.rpy:94
 translate english ESCOLHA_CONV_DIA2C3_66b31a6e:
 
     # drc "Estou ciente, [ind_b_info[1]]. Mas peço colaboração."
-    drc ""
+    drc "I'm aware, [ind_b_info[1]]. But I ask for your cooperation."
 
 # game/cenas/dia2/cena23.rpy:95
 translate english ESCOLHA_CONV_DIA2C3_29e58883:
 
     # drc "Me diga o que você sabe, o que você viu na noite em que seu [ind_b_info[2]] foi assassinado."
-    drc ""
+    drc "Tell me what you know, what you saw the night your [ind_b_info[2]] was murdered."
 
 # game/cenas/dia2/cena23.rpy:96
 translate english ESCOLHA_CONV_DIA2C3_e9f76ee5:
 
     # drc "Quem subiu ao quarto?"
-    drc ""
+    drc "Who went up to the room?"
 
 # game/cenas/dia2/cena23.rpy:97
 translate english ESCOLHA_CONV_DIA2C3_f5bd5cf4:
 
     # ind_b "Creio ter sido a primeira pessoa a subir ao quarto. Meu [ind_b_info[2]] estava acamado."
-    ind_b ""
+    ind_b "I believe I was the first person to go up to the room. My [ind_b_info[2]] was bedridden."
 
 # game/cenas/dia2/cena23.rpy:98
 translate english ESCOLHA_CONV_DIA2C3_d48e6e7d:
 
     # "Certo... Preciso ficar atento a cada detalhe."
-    ""
+    "Right... I need to stay alert to every detail."
 
 # game/cenas/dia2/cena23.rpy:99
 translate english ESCOLHA_CONV_DIA2C3_c29c2639:
 
     # ind_b "Ele tossia muito. Dei-lhe água."
-    ind_b ""
+    ind_b "He was coughing a lot. I gave him water."
 
 # game/cenas/dia2/cena23.rpy:100
 translate english ESCOLHA_CONV_DIA2C3_e1c80274:
 
     # ind_b "Após isso, voltei ao salão."
-    ind_b ""
+    ind_b "After that, I returned to the parlor."
 
 # game/cenas/dia2/cena23.rpy:101
 translate english ESCOLHA_CONV_DIA2C3_8a818c0b:
 
     # ind_b "Passado algum tempo, vi descerem Kamira e [ind_a_info[1]]."
-    ind_b ""
+    ind_b "Some time later, I saw Kamira and [ind_a_info[1]] come down."
 
 # game/cenas/dia2/cena23.rpy:102
 translate english ESCOLHA_CONV_DIA2C3_4d8356c0:
 
     # drc "O que faziam?"
-    drc ""
+    drc "What were they doing?"
 
 # game/cenas/dia2/cena23.rpy:103
 translate english ESCOLHA_CONV_DIA2C3_da90ab0f:
 
     # ind_b "Kamira estava chorando ao canto e [ind_a_info[1]] a consolava."
-    ind_b ""
+    ind_b "Kamira was crying in the corner and [ind_a_info[1]] was comforting her."
 
 # game/cenas/dia2/cena23.rpy:105
 translate english ESCOLHA_CONV_DIA2C3_5eb61b1b:
 
     # drc "Sabe me dizer o motivo?"
-    drc ""
+    drc "Can you tell me the reason?"
 
 # game/cenas/dia2/cena23.rpy:106
 translate english ESCOLHA_CONV_DIA2C3_47969097:
 
     # ind_b "Parece que houve uma discussão entre ela e meu [ind_b_info[2]]."
-    ind_b ""
+    ind_b "It seems there was an argument between her and my [ind_b_info[2]]."
 
 # game/cenas/dia2/cena23.rpy:107
 translate english ESCOLHA_CONV_DIA2C3_e38e7290:
 
     # drc "Certo. Mais alguma coisa?"
-    drc ""
+    drc "Right. Anything else?"
 
 # game/cenas/dia2/cena23.rpy:108
 translate english ESCOLHA_CONV_DIA2C3_7bb5f291:
 
     # ind_b "É tudo o que eu sei..."
-    ind_b ""
+    ind_b "That's all I know..."
 
 # game/cenas/dia2/cena23.rpy:109
 translate english ESCOLHA_CONV_DIA2C3_811d3117:
 
     # "Verificarei com [ind_a_info[1]] depois..."
-    ""
+    "I'll check with [ind_a_info[1]] later..."
 
 # game/cenas/dia2/cena23.rpy:111
 translate english ESCOLHA_CONV_DIA2C3_120ed4eb:
 
     # "Parece que [ind_a_info[1]] falava a verdade."
-    ""
+    "It seems [ind_a_info[1]] was telling the truth."
 
 # game/cenas/dia2/cena23.rpy:112
 translate english ESCOLHA_CONV_DIA2C3_0a130ac8_2:
 
     # drc "Entendo."
-    drc ""
+    drc "I see."
 
 # game/cenas/dia2/cena23.rpy:113
 translate english ESCOLHA_CONV_DIA2C3_d0a4871d_1:
 
     # drc "Mais uma coisa..."
-    drc ""
+    drc "One more thing..."
 
 # game/cenas/dia2/cena23.rpy:114
 translate english ESCOLHA_CONV_DIA2C3_1ae064be_1:
 
     # drc "Pode me contar como era o senhor Sheppard? Digo, no dia a dia da família."
-    drc ""
+    drc "Can you tell me what Mr. Sheppard was like? I mean, in the family's daily life."
 
 # game/cenas/dia2/cena23.rpy:115
 translate english ESCOLHA_CONV_DIA2C3_cf7c73b5:
 
     # ind_b "Sheppard era uma homem leal. Fazia parte da nossa família. Nos viu crescer, dentro desta casa."
-    ind_b ""
+    ind_b "Sheppard was a loyal man. He was part of our family. He watched us grow up, inside this house."
 
 # game/cenas/dia2/cena23.rpy:116
 translate english ESCOLHA_CONV_DIA2C3_401b8699:
 
     # ind_b "..."
-    ind_b ""
+    ind_b "..."
 
 # game/cenas/dia2/cena23.rpy:117
 translate english ESCOLHA_CONV_DIA2C3_0ad68aa7:
 
     # ind_b "Ainda não acredito que isso esteja acontecendo..."
-    ind_b ""
+    ind_b "I still can't believe this is happening..."
 
 # game/cenas/dia2/cena23.rpy:118
 translate english ESCOLHA_CONV_DIA2C3_9a21346b:
 
     # ind_b "É horrível, senhor"
-    ind_b ""
+    ind_b "It's horrible, sir"
 
 # game/cenas/dia2/cena23.rpy:119
 translate english ESCOLHA_CONV_DIA2C3_6d3cccca_1:
 
     # drc "Compreendo."
-    drc ""
+    drc "I understand."
 
 # game/cenas/dia2/cena23.rpy:120
 translate english ESCOLHA_CONV_DIA2C3_c0c9c6ad:
 
     # drc "Bom, era só isso que eu precisava escutar por agora. Descanse um pouco, [ind_b_info[1]]."
-    drc ""
+    drc "Well, that's all I needed to hear for now. Get some rest, [ind_b_info[1]]."
 
 # game/cenas/dia2/cena23.rpy:139
 translate english ESCOLHA_CONV_DIA2C3_a20cefa7_2:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena23.rpy:140
 translate english ESCOLHA_CONV_DIA2C3_537a7b27_1:
 
     # "Certo, já tenho um destino."
-    ""
+    "Right, I have somewhere to go now."
 
 # game/cenas/dia2/cena23.rpy:148
 translate english ESCOLHA_CONV_DIA2C3_f5997ffd:
 
     # "Ela está aflita. E parece chorar."
-    ""
+    "She's distressed. And she seems to be crying."
 
 # game/cenas/dia2/cena23.rpy:149
 translate english ESCOLHA_CONV_DIA2C3_794057c4:
 
     # "Talvez eu deva me aproximar em breve, mas darei um tempo."
-    ""
+    "Maybe I should approach her soon, but I'll give it some time."
 
 # game/cenas/dia2/cena23.rpy:150
 translate english ESCOLHA_CONV_DIA2C3_2b650c4f:
 
     # "Talvez se eu investigasse outro herdeiro..."
-    ""
+    "Maybe if I investigated another heir..."
 
 # game/cenas/dia2/cena23.rpy:155
 translate english ESCOLHA_CONV_DIA2C3_50ea76d9:
 
     # "Já decidi não incomodá-la. Pelo menos por agora..."
-    ""
+    "I've already decided not to bother her. At least for now..."
 
 # game/cenas/dia2/cena23.rpy:159
 translate english ESCOLHA_CONV_DIA2C3_c22f0ffa:
 
     # "Descobri uma evidência forte. Mas preciso de mais detalhes de terceiros antes de verificar a versão dela da história."
-    ""
+    "I've found strong evidence. But I need more details from others before checking her version of the story."
 
 # game/cenas/dia2/cena23.rpy:160
 translate english ESCOLHA_CONV_DIA2C3_369195de:
 
     # "Talvez eu devesse..."
-    ""
+    "Maybe I should..."
 
 # game/cenas/dia2/cena23.rpy:163
 translate english ESCOLHA_CONV_DIA2C3_333f50c8:
 
     # "Tenho o controle da situação."
-    ""
+    "I have the situation under control."
 
 # game/cenas/dia2/cena23.rpy:164
 translate english ESCOLHA_CONV_DIA2C3_ffeba4aa:
 
     # "Devo agir com sabedoria."
-    ""
+    "I must act wisely."
 
 # game/cenas/dia2/cena23.rpy:165
 translate english ESCOLHA_CONV_DIA2C3_a20cefa7_3:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena23.rpy:166
 translate english ESCOLHA_CONV_DIA2C3_c8e6cec7:
 
     # drc "Senhorita. Com licença"
-    drc ""
+    drc "Miss. Excuse me"
 
 # game/cenas/dia2/cena23.rpy:170
 translate english ESCOLHA_CONV_DIA2C3_f7908349:
 
     # kmr "O que deseja, detetive?"
-    kmr ""
+    kmr "What do you want, detective?"
 
 # game/cenas/dia2/cena23.rpy:171
 translate english ESCOLHA_CONV_DIA2C3_80b4ac58:
 
     # "Com calma e astúcia..."
-    ""
+    "Calmly and with cunning..."
 
 # game/cenas/dia2/cena23.rpy:172
 translate english ESCOLHA_CONV_DIA2C3_f85b27d9:
 
     # drc "Meus pêsames por outra perda. Eu gostaria que soubesse que gastarei todo meu esforço para descobrir quem está por trás disso."
-    drc ""
+    drc "My condolences for another loss. I'd like you to know that I will spend all my effort to find out who is behind this."
 
 # game/cenas/dia2/cena23.rpy:173
 translate english ESCOLHA_CONV_DIA2C3_fb6cf606:
 
     # drc "Vocês têm a minha palavra."
-    drc ""
+    drc "You all have my word."
 
 # game/cenas/dia2/cena23.rpy:174
 translate english ESCOLHA_CONV_DIA2C3_bd5c1205:
 
     # kmr "Mesmo agora, o senhor permanece. Por quê?"
-    kmr ""
+    kmr "Even now, you remain. Why?"
 
 # game/cenas/dia2/cena23.rpy:175
 translate english ESCOLHA_CONV_DIA2C3_cd5f0554:
 
     # "Muito supeito... Bom, serei franco."
-    ""
+    "Very suspicious... Well, I'll be frank."
 
 # game/cenas/dia2/cena23.rpy:176
 translate english ESCOLHA_CONV_DIA2C3_81fbed14:
 
     # drc "Fui inspirado por um certo homem, que permaneceu leal a sua palavra, mesmo depois de quem a exigiu partir."
-    drc ""
+    drc "I was inspired by a certain man who stayed true to his word, even after the one who demanded it was gone."
 
 # game/cenas/dia2/cena23.rpy:177
 translate english ESCOLHA_CONV_DIA2C3_ec341b53:
 
     # drc "Encontrarei o culpado, pode ter certeza. Mas preciso da sua colaboração."
-    drc ""
+    drc "I will find the culprit, you can be sure of that. But I need your cooperation."
 
 # game/cenas/dia2/cena23.rpy:178
 translate english ESCOLHA_CONV_DIA2C3_a784ac0f:
 
     # kmr "E o que o senhor precisa de mim?"
-    kmr ""
+    kmr "And what do you need from me?"
 
 # game/cenas/dia2/cena23.rpy:179
 translate english ESCOLHA_CONV_DIA2C3_67913a49:
 
     # "Ela derruba lágrimas. Serão verdadeiras?"
-    ""
+    "She sheds tears. Are they real?"
 
 # game/cenas/dia2/cena23.rpy:180
 translate english ESCOLHA_CONV_DIA2C3_2ac61726:
 
     # "Acho difícil. Dado o que todos disseram. Mas devo ter calma..."
-    ""
+    "I find it doubtful. Given what everyone has said. But I must stay calm..."
 
 # game/cenas/dia2/cena23.rpy:181
 translate english ESCOLHA_CONV_DIA2C3_c577b87a:
 
     # drc "Preciso que me diga o que aconteceu na noite em que seu tio morreu."
-    drc ""
+    drc "I need you to tell me what happened the night your uncle died."
 
 # game/cenas/dia2/cena23.rpy:182
 translate english ESCOLHA_CONV_DIA2C3_701741b1:
 
     # drc "Viu algo estranho? Algo diferente? O que aconteceu naquela noite, senhorita Kamira?"
-    drc ""
+    drc "Did you see anything strange? Anything different? What happened that night, Miss Kamira?"
 
 # game/cenas/dia2/cena23.rpy:183
 translate english ESCOLHA_CONV_DIA2C3_23eaa03b:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena23.rpy:184
 translate english ESCOLHA_CONV_DIA2C3_197dd7a4:
 
     # "Ela acena em negação com a cabeça. A informação que ela guarda é decisiva."
-    ""
+    "She shakes her head no. The information she's holding is decisive."
 
 # game/cenas/dia2/cena23.rpy:185
 translate english ESCOLHA_CONV_DIA2C3_923a585f:
 
     # drc "Senhorita, por favor, ajude-me a resolver isso."
-    drc ""
+    drc "Miss, please, help me solve this."
 
 # game/cenas/dia2/cena23.rpy:186
 translate english ESCOLHA_CONV_DIA2C3_97eb752f:
 
     # drc "Preciso da sua palavra. Minhas conclusões estão convergindo para uma pessoa."
-    drc ""
+    drc "I need your word. My conclusions are converging on one person."
 
 # game/cenas/dia2/cena23.rpy:187
 translate english ESCOLHA_CONV_DIA2C3_b4b116b7:
 
     # "Tenho o controle da situação. Estou te jogando contra a parede. O que me diz?"
-    ""
+    "I have the situation under control. I'm backing you against the wall. What do you say?"
 
 # game/cenas/dia2/cena23.rpy:188
 translate english ESCOLHA_CONV_DIA2C3_23eaa03b_1:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena23.rpy:193
 translate english ESCOLHA_CONV_DIA2C3_92d88b53:
 
     # kmr "Eu não pude me desculpar. Não pude."
-    kmr ""
+    kmr "I couldn't apologize. I couldn't."
 
 # game/cenas/dia2/cena23.rpy:194
 translate english ESCOLHA_CONV_DIA2C3_bf6c1250:
 
     # kmr "Poderia ter sido diferente."
-    kmr ""
+    kmr "It could have been different."
 
 # game/cenas/dia2/cena23.rpy:195
 translate english ESCOLHA_CONV_DIA2C3_608fe045:
 
     # drc "Do que a senhorita fala? Me conte de uma vez."
-    drc ""
+    drc "What are you talking about, miss? Tell me at once."
 
 # game/cenas/dia2/cena23.rpy:196
 translate english ESCOLHA_CONV_DIA2C3_517c50c7:
 
     # kmr "Era só ele ter dito..."
-    kmr ""
+    kmr "If only he had said..."
 
 # game/cenas/dia2/cena23.rpy:197
 translate english ESCOLHA_CONV_DIA2C3_dc2aa768:
 
     # kmr "Dito o maldito nome..."
-    kmr ""
+    kmr "Said the damned name..."
 
 # game/cenas/dia2/cena23.rpy:198
 translate english ESCOLHA_CONV_DIA2C3_23eaa03b_2:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena23.rpy:199
 translate english ESCOLHA_CONV_DIA2C3_0ac56fc2:
 
     # "Do que ela está falando?"
-    ""
+    "What is she talking about?"
 
 # game/cenas/dia2/cena23.rpy:200
 translate english ESCOLHA_CONV_DIA2C3_c5971230:
 
     # drc "Calma, senhorita."
-    drc ""
+    drc "Calm down, miss."
 
 # game/cenas/dia2/cena23.rpy:204
 translate english ESCOLHA_CONV_DIA2C3_11099ff2:
 
     # kmr "Com licença."
-    kmr ""
+    kmr "Excuse me."
 
 # game/cenas/dia2/cena23.rpy:205
 translate english ESCOLHA_CONV_DIA2C3_5e24fe59:
 
     # drc "Senhorita?"
-    drc ""
+    drc "Miss?"
 
 # game/cenas/dia2/cena23.rpy:209
 translate english ESCOLHA_CONV_DIA2C3_d3284573:
 
     # "Ela se foi..."
-    ""
+    "She's gone..."
 
 # game/cenas/dia2/cena23.rpy:210
 translate english ESCOLHA_CONV_DIA2C3_d91ee435:
 
     # "Chorando."
-    ""
+    "Crying."
 
 # game/cenas/dia2/cena23.rpy:211
 translate english ESCOLHA_CONV_DIA2C3_5a60bb5f:
 
     # "Não posso errar. Minha decisão é crucial."
-    ""
+    "I can't be wrong. My decision is crucial."
 
 # game/cenas/dia2/cena23.rpy:217
 translate english ESCOLHA_CONV_DIA2C3_b4a175f5:
 
     # "Mas também não posso me apressar e condenar alguém inocente."
-    ""
+    "But I also can't rush and condemn someone innocent."
 
 # game/cenas/dia2/cena23.rpy:218
 translate english ESCOLHA_CONV_DIA2C3_338c7afb:
 
     # "Talvez eu deva dar uma volta pela parte externa e ver se consigo notar algo na edificação, pode ser uma possibilidade para acesso e fuga."
-    ""
+    "Maybe I should walk around the outside and see if I can spot something about the building; it could be a possible way in and out."
 
 # game/cenas/dia2/cena23.rpy:219
 translate english ESCOLHA_CONV_DIA2C3_09ac49d6:
 
     # "Joe chegou."
-    ""
+    "Joe has arrived."
 
 # game/cenas/dia2/cena23.rpy:220
 translate english ESCOLHA_CONV_DIA2C3_d554035e:
 
     # "Ele irá direto para dentro."
-    ""
+    "He'll go straight inside."
 
 # game/cenas/dia2/cena23.rpy:221
 translate english ESCOLHA_CONV_DIA2C3_98c168f0:
 
     # drc "Joe. Podemos conversar um instante?"
-    drc ""
+    drc "Joe. Can we talk for a moment?"
 
 # game/cenas/dia2/cena23.rpy:226
 translate english ESCOLHA_CONV_DIA2C3_317eee78:
 
     # joe "Por favor, senhor Rightclue. Me dê um tempo."
-    joe ""
+    joe "Please, Mr. Rightclue. Give me some time."
 
 # game/cenas/dia2/cena23.rpy:227
 translate english ESCOLHA_CONV_DIA2C3_c1ffd248:
 
     # joe "Preciso assimilar tudo isso."
-    joe ""
+    joe "I need to take all of this in."
 
 # game/cenas/dia2/cena23.rpy:228
 translate english ESCOLHA_CONV_DIA2C3_92ba0f99:
 
     # drc "Tudo bem. Entendo."
-    drc ""
+    drc "It's all right. I understand."
 
 # game/cenas/dia2/cena23.rpy:229
 translate english ESCOLHA_CONV_DIA2C3_5ceb3fb2:
 
     # drc "Mas por favor, podemos conversar mais tarde?"
-    drc ""
+    drc "But please, can we talk later?"
 
 # game/cenas/dia2/cena23.rpy:230
 translate english ESCOLHA_CONV_DIA2C3_9891dc61:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia2/cena23.rpy:231
 translate english ESCOLHA_CONV_DIA2C3_05581b7b:
 
     # joe "Talvez mais tarde, detetive."
-    joe ""
+    joe "Maybe later, detective."
 
 # game/cenas/dia2/cena23.rpy:235
 translate english ESCOLHA_CONV_DIA2C3_a1763666:
 
     # "Bom, que seja, tentarei falar com ele novamente em breve."
-    ""
+    "Well, so be it, I'll try to speak with him again soon."
 
 # game/cenas/dia2/cena23.rpy:236
 translate english ESCOLHA_CONV_DIA2C3_c7dadd87:
 
     # "Agora, ao estudo da edificação."
-    ""
+    "Now, to studying the building."
 
 # game/cenas/dia2/cena23.rpy:244
 translate english ESCOLHA_CONV_DIA2C3_a20cefa7_4:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena23.rpy:251
 translate english DIALOGO_ROLES_D2C3_fb374764:
 
     # drc "[ind_a_info[1]], com licença, podemos conversar um instante?"
-    drc ""
+    drc "[ind_a_info[1]], excuse me, can we talk for a moment?"
 
 # game/cenas/dia2/cena23.rpy:253
 translate english DIALOGO_ROLES_D2C3_0b591dda:
 
     # drc "[ind_b_info[1]], com licença, podemos conversar um instante?"
-    drc ""
+    drc "[ind_b_info[1]], excuse me, can we talk for a moment?"
 
 # game/cenas/dia2/cena23.rpy:261
 translate english DIALOGO_ROLES_D2C3_a5810d10:
 
     # hugo "Senhor Rightclue..."
-    hugo ""
+    hugo "Mr. Rightclue..."
 
 # game/cenas/dia2/cena23.rpy:262
 translate english DIALOGO_ROLES_D2C3_ad89f289:
 
     # hugo "Claro."
-    hugo ""
+    hugo "Of course."
 
 # game/cenas/dia2/cena23.rpy:263
 translate english DIALOGO_ROLES_D2C3_341456a2:
 
     # hugo "Ainda estou um pouco chocado com tudo, mas acho que uma companhia viria bem, senhor Rightclue."
-    hugo ""
+    hugo "I'm still a bit shaken by everything, but I think some company would be welcome, Mr. Rightclue."
 
 # game/cenas/dia2/cena23.rpy:264
 translate english DIALOGO_ROLES_D2C3_e29a659e:
 
     # hugo "Tanto para mim, quanto para o Thorn."
-    hugo ""
+    hugo "For me and for Thorn alike."
 
 # game/cenas/dia2/cena23.rpy:265
 translate english DIALOGO_ROLES_D2C3_d301370f:
 
     # hugo "Mas ele me consola bastante."
-    hugo ""
+    hugo "But he comforts me a lot."
 
 # game/cenas/dia2/cena23.rpy:266
 translate english DIALOGO_ROLES_D2C3_371632f7:
 
     # hugo "Não é, garotão?"
-    hugo ""
+    hugo "Isn't that right, big guy?"
 
 # game/cenas/dia2/cena23.rpy:269
 translate english DIALOGO_ROLES_D2C3_b6df5c1c:
 
     # drc "Entendo, você e sua familia estão passando por um momento dificil."
-    drc ""
+    drc "I understand; you and your family are going through a difficult time."
 
 # game/cenas/dia2/cena23.rpy:270
 translate english DIALOGO_ROLES_D2C3_aad732b2:
 
     # hugo "Está sendo difícil para todos... e tenho medo do que pode acontecer nos proximos dias com o resto de nós."
-    hugo ""
+    hugo "It's been hard on everyone... and I'm afraid of what might happen in the coming days to the rest of us."
 
 # game/cenas/dia2/cena23.rpy:277
 translate english DIALOGO_ROLES_D2C3_7a3cb5a4:
 
     # cth "O que deseja, detetive?"
-    cth ""
+    cth "What do you want, detective?"
 
 # game/cenas/dia2/cena23.rpy:278
 translate english DIALOGO_ROLES_D2C3_5cbdb455:
 
     # drc "Eu gostaria que soubesse que gastarei todo meu esforço para descobrir quem está por trás disso."
-    drc ""
+    drc "I'd like you to know that I will spend all my effort to find out who is behind this."
 
 # game/cenas/dia2/cena23.rpy:279
 translate english DIALOGO_ROLES_D2C3_2935440c:
 
     # cth "O senhor permaneceu. Parece disposto a realmente resolver o caso."
-    cth ""
+    cth "You stayed. You seem willing to truly solve the case."
 
 # game/cenas/dia2/cena23.rpy:280
 translate english DIALOGO_ROLES_D2C3_1d9835ce:
 
     # cth "É realmente uma boa pessoa, detetive."
-    cth ""
+    cth "You really are a good person, detective."
 
 # game/cenas/dia2/cena23.rpy:281
 translate english DIALOGO_ROLES_D2C3_887b9537:
 
     # cth "O senhor parece determinado."
-    cth ""
+    cth "You seem determined."
 
 # game/cenas/dia2/cena23.rpy:282
 translate english DIALOGO_ROLES_D2C3_13403d59:
 
     # cth "Estamos sem tempo, detetive."
-    cth ""
+    cth "We're out of time, detective."
 
 # game/cenas/dia2/cena23.rpy:283
 translate english DIALOGO_ROLES_D2C3_9c1436d4:
 
     # cth "O culpado está nos eliminando. Um a um."
-    cth ""
+    cth "The culprit is eliminating us. One by one."
 
 # game/cenas/dia2/cena23.rpy:284
 translate english DIALOGO_ROLES_D2C3_4b7f63e4:
 
     # cth "Precisamos de respostas."
-    cth ""
+    cth "We need answers."
 
 translate english strings:
 
     # game/cenas/dia2/cena23.rpy:18
     old "Vejamos..."
-    new ""
+    new "Let's see..."
 
     # game/cenas/dia2/cena23.rpy:18
     old "Conversar com [ind_a_info[0]]"
-    new ""
+    new "Talk to [ind_a_info[0]]"
 
     # game/cenas/dia2/cena23.rpy:18
     old "Conversar com [ind_b_info[0]]"
-    new ""
+    new "Talk to [ind_b_info[0]]"
 
     # game/cenas/dia2/cena23.rpy:18
     old "Conversar com Kamira T. Cashand"
-    new ""
+    new "Talk to Kamira T. Cashand"
 

--- a/game/tl/english/cenas/dia2/cena24.rpy
+++ b/game/tl/english/cenas/dia2/cena24.rpy
@@ -4,167 +4,167 @@
 translate english CENA24_e094ebb5:
 
     # "Certo. Tenho noção de todos os acessos possíveis a janelas. Já tenho noção interna dos corredores e dos quartos."
-    ""
+    "Right. I have a sense of every possible access to the windows. I already know the layout of the corridors and rooms."
 
 # game/cenas/dia2/cena24.rpy:3
 translate english CENA24_913ae7c8:
 
     # "Consigo concluir que o herdeiro assassino entra e sai pela porta do quarto, normalmente."
-    ""
+    "I can conclude that the murderous heir enters and leaves through the room's door, normally."
 
 # game/cenas/dia2/cena24.rpy:4
 translate english CENA24_e5c939c5:
 
     # "Talvez chegue ao quarto com uma conversa comum, e logo após, ataca a vítima. Hougin, Sheppard..."
-    ""
+    "Perhaps he comes to the room with ordinary conversation, and right after, attacks the victim. Hougin, Sheppard..."
 
 # game/cenas/dia2/cena24.rpy:5
 translate english CENA24_1cf7b060:
 
     # "O curioso é o senhor Lostie, que foi assassinado no jardim da mansão, pelo que entendi, na madrugada."
-    ""
+    "The curious one is Mr. Lostie, who was murdered in the mansion's garden, from what I understand, in the small hours."
 
 # game/cenas/dia2/cena24.rpy:6
 translate english CENA24_7a6ea175:
 
     # "Realmente é algo intrigante..."
-    ""
+    "It really is something intriguing..."
 
 # game/cenas/dia2/cena24.rpy:7
 translate english CENA24_544aff31:
 
     # "Está escurendo, preciso falar com Joe."
-    ""
+    "It's getting dark, I need to talk to Joe."
 
 # game/cenas/dia2/cena24.rpy:26
 translate english CENA24_b2eb595e:
 
     # "Essa é a porta do quarto de Kamira."
-    ""
+    "That's the door to Kamira's room."
 
 # game/cenas/dia2/cena24.rpy:27
 translate english CENA24_5b55cedf:
 
     # "Talvez eu devesse insistir mais uma vez, aproveitando que já estou por aqui."
-    ""
+    "Maybe I should try once more, since I'm already here."
 
 # game/cenas/dia2/cena24.rpy:32
 translate english CENA24_36c08a89:
 
     # "Sem resposta."
-    ""
+    "No answer."
 
 # game/cenas/dia2/cena24.rpy:33
 translate english CENA24_2313c2f9:
 
     # "A porta parece levemente aberta."
-    ""
+    "The door seems slightly open."
 
 # game/cenas/dia2/cena24.rpy:34
 translate english CENA24_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena24.rpy:35
 translate english CENA24_9ef9be9b:
 
     # "Está aberta."
-    ""
+    "It's open."
 
 # game/cenas/dia2/cena24.rpy:36
 translate english CENA24_9c43cfca:
 
     # drc "Senhorita? Posso entrar?"
-    drc ""
+    drc "Miss? May I come in?"
 
 # game/cenas/dia2/cena24.rpy:37
 translate english CENA24_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena24.rpy:42
 translate english CENA24_707deb44:
 
     # "Mas que som é esse?"
-    ""
+    "What is that sound?"
 
 # game/cenas/dia2/cena24.rpy:43
 translate english CENA24_bf30e636:
 
     # "Será que...?"
-    ""
+    "Could it be...?"
 
 # game/cenas/dia2/cena24.rpy:44
 translate english CENA24_af3cb326:
 
     # drc "Senhorita!"
-    drc ""
+    drc "Miss!"
 
 # game/cenas/dia2/cena24.rpy:54
 translate english CENA24_03f4af83:
 
     # drc "Não..."
-    drc ""
+    drc "No..."
 
 # game/cenas/dia2/cena24.rpy:59
 translate english CENA24_640485ea:
 
     # drc "Não pode ser..."
-    drc ""
+    drc "It can't be..."
 
 # game/cenas/dia2/cena24.rpy:64
 translate english CENA24_eb13dd2f:
 
     # "Seria ela a culpada? Suicídio por sentir-se encurralada?"
-    ""
+    "Could she be the culprit? Suicide from feeling cornered?"
 
 # game/cenas/dia2/cena24.rpy:65
 translate english CENA24_70fa547a:
 
     # "Eu não sei."
-    ""
+    "I don't know."
 
 # game/cenas/dia2/cena24.rpy:71
 translate english CENA24_34def47a:
 
     # "Eu não entendo."
-    ""
+    "I don't understand."
 
 # game/cenas/dia2/cena24.rpy:72
 translate english CENA24_709f6348:
 
     # "Não faz sentido..."
-    ""
+    "It doesn't make sense..."
 
 # game/cenas/dia2/cena24.rpy:77
 translate english CENA24_db0789b2:
 
     # "O que é aquilo?"
-    ""
+    "What is that?"
 
 # game/cenas/dia2/cena24.rpy:78
 translate english CENA24_efc34588:
 
     # "Tem algo em sua boca..."
-    ""
+    "There's something in her mouth..."
 
 # game/cenas/dia2/cena24.rpy:81
 translate english CENA24_14007298:
 
     # "Pode ser uma pista muito importante, vou levar."
-    ""
+    "It could be a very important clue, I'll take it."
 
 # game/cenas/dia2/cena24.rpy:86
 translate english CENA24_42ff2b6d:
 
     # "Preciso avisar os outros."
-    ""
+    "I need to warn the others."
 
 # game/cenas/dia2/cena24.rpy:87
 translate english CENA24_e0f1b93b:
 
     # "Essa será uma longa noite..."
-    ""
+    "This is going to be a long night..."
 

--- a/game/tl/english/cenas/dia2/cena25.rpy
+++ b/game/tl/english/cenas/dia2/cena25.rpy
@@ -4,653 +4,653 @@
 translate english CENA25_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:9
 translate english CENA25_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:10
 translate english CENA25_a20cefa7_2:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:11
 translate english CENA25_3fe6968e:
 
     # "O que foi tudo isso?"
-    ""
+    "What was all of that?"
 
 # game/cenas/dia2/cena25.rpy:12
 translate english CENA25_a60bafd2:
 
     # "Qual o sentido desses eventos?"
-    ""
+    "What's the meaning of these events?"
 
 # game/cenas/dia2/cena25.rpy:13
 translate english CENA25_87421355:
 
     # "Quem é o culpado?"
-    ""
+    "Who is the culprit?"
 
 # game/cenas/dia2/cena25.rpy:14
 translate english CENA25_a20cefa7_3:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:15
 translate english CENA25_7b77673f:
 
     # "Estão preparando o velório de Kamira."
-    ""
+    "They're preparing Kamira's wake."
 
 # game/cenas/dia2/cena25.rpy:17
 translate english CENA25_0b86a040:
 
     # "Assim como Sheppard, ela será enterrada amanhã de manhã."
-    ""
+    "Like Sheppard, she will be buried tomorrow morning."
 
 # game/cenas/dia2/cena25.rpy:18
 translate english CENA25_6820496e:
 
     # "Preciso pensar..."
-    ""
+    "I need to think..."
 
 # game/cenas/dia2/cena25.rpy:22
 translate english CENA25_20f146a0:
 
     # "Talvez se eu..."
-    ""
+    "Maybe if I..."
 
 # game/cenas/dia2/cena25.rpy:27
 translate english CENA25_c39d6efa:
 
     # "Gravador cômoda senha culpado"
-    ""
+    "Recorder... dresser... password... culprit"
 
 # game/cenas/dia2/cena25.rpy:29
 translate english CENA25_2a6b6c3c:
 
     # "Espere um pouco... É isso..."
-    ""
+    "Wait a moment... That's it..."
 
 # game/cenas/dia2/cena25.rpy:30
 translate english CENA25_a20cefa7_4:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:50
 translate english CENA25_151ba5ed:
 
     # "Se eu não estiver enganado..."
-    ""
+    "If I'm not mistaken..."
 
 # game/cenas/dia2/cena25.rpy:54
 translate english CENA25_484a0ead:
 
     # "Analisando os fatos..."
-    ""
+    "Analyzing the facts..."
 
 # game/cenas/dia2/cena25.rpy:58
 translate english CENA25_8084e977:
 
     # "Bom, vamos tentar..."
-    ""
+    "Well, let's try..."
 
 # game/cenas/dia2/cena25.rpy:65
 translate english CENA25_b5d1863d:
 
     # "Excelente. Agora a tampa pode ser fechada."
-    ""
+    "Excellent. Now the lid can be closed."
 
 # game/cenas/dia2/cena25.rpy:69
 translate english CENA25_5d64622a:
 
     # "Ligo o gravador na tomada e..."
-    ""
+    "I plug the recorder into the outlet and..."
 
 # game/cenas/dia2/cena25.rpy:70
 translate english CENA25_26a304c0:
 
     # "Hmmm..."
-    ""
+    "Hmmm..."
 
 # game/cenas/dia2/cena25.rpy:71
 translate english CENA25_d70a43be:
 
     # "Basta setar o modo de reprodução e..."
-    ""
+    "I just set it to playback mode and..."
 
 # game/cenas/dia2/cena25.rpy:72
 translate english CENA25_a20cefa7_5:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:73
 translate english CENA25_a20cefa7_6:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:74
 translate english CENA25_e67a8f2e:
 
     # drc "Mas que droga!"
-    drc ""
+    drc "Damn it!"
 
 # game/cenas/dia2/cena25.rpy:75
 translate english CENA25_a20cefa7_7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:76
 translate english CENA25_1ad29a5f:
 
     # drc "Quebrado. Claro."
-    drc ""
+    drc "Broken. Of course."
 
 # game/cenas/dia2/cena25.rpy:77
 translate english CENA25_a20cefa7_8:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:78
 translate english CENA25_a20cefa7_9:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:79
 translate english CENA25_953ba315:
 
     # "Hmm?"
-    ""
+    "Hmm?"
 
 # game/cenas/dia2/cena25.rpy:80
 translate english CENA25_a20cefa7_10:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:81
 translate english CENA25_0fe71b30:
 
     # drc "O senhor era mesmo um homem astuto, senhor Hougin."
-    drc ""
+    drc "You really were a shrewd man, Mr. Hougin."
 
 # game/cenas/dia2/cena25.rpy:82
 translate english CENA25_4a138075:
 
     # drc "Quem diria possuir um artefato dessa complexidade."
-    drc ""
+    drc "Who would have thought he'd own a device of such complexity."
 
 # game/cenas/dia2/cena25.rpy:83
 translate english CENA25_01ef48cd:
 
     # "Há um segundo sistema. Dessa vez parece algum tipo de ativação elétrica."
-    ""
+    "There's a second system. This time it looks like some kind of electrical activation."
 
 # game/cenas/dia2/cena25.rpy:84
 translate english CENA25_1cf21ac9:
 
     # "Isso é tecnologia de ponta. Realmente fascinante."
-    ""
+    "This is cutting-edge technology. Truly fascinating."
 
 # game/cenas/dia2/cena25.rpy:86
 translate english CENA25_2005d2cf:
 
     # "Bom, vamos à tentativa..."
-    ""
+    "Well, let's give it a try..."
 
 # game/cenas/dia2/cena25.rpy:93
 translate english CENA25_d2b2c51d:
 
     # "Excelente!"
-    ""
+    "Excellent!"
 
 # game/cenas/dia2/cena25.rpy:94
 translate english CENA25_e66b8e85:
 
     # "Agora.... Escutemos..."
-    ""
+    "Now.... Let's listen..."
 
 # game/cenas/dia2/cena25.rpy:95
 translate english CENA25_a20cefa7_11:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:96
 translate english CENA25_5a4c72a1:
 
     # "..z....sh.....zh.....sh.....z..."
-    ""
+    "..z....sh.....zh.....sh.....z..."
 
 # game/cenas/dia2/cena25.rpy:97
 translate english CENA25_001fc8de:
 
     # kmr "hzGora.... zhsh.... im.... Está po...shz... cionado."
-    kmr ""
+    kmr "hzNow.... zhsh.... ye.... It is po...shz...sitioned."
 
 # game/cenas/dia2/cena25.rpy:98
 translate english CENA25_5520ee97:
 
     # kmr "Pronto. Tio, isto monitorará o senhor mais esta noite."
-    kmr ""
+    kmr "There. Uncle, this will monitor you for one more night."
 
 # game/cenas/dia2/cena25.rpy:99
 translate english CENA25_6393e178:
 
     # hgin "Não preciso destas tranqueiras."
-    hgin ""
+    hgin "I don't need these contraptions."
 
 # game/cenas/dia2/cena25.rpy:100
 translate english CENA25_e7da5e35:
 
     # kmr "Será benéfico ao senhor. Podemos mostrar suas tosses e faltas de ar ao médico."
-    kmr ""
+    kmr "It will be good for you. We can show your coughing and shortness of breath to the doctor."
 
 # game/cenas/dia2/cena25.rpy:101
 translate english CENA25_f418d474:
 
     # kmr "Tenho certeza que no futuro isso será muito usado."
-    kmr ""
+    kmr "I'm sure that in the future this will be widely used."
 
 # game/cenas/dia2/cena25.rpy:102
 translate english CENA25_7c4ba133:
 
     # hgin "Ora, vamos. Como se eu fosse um velho prestes a morrer..."
-    hgin ""
+    hgin "Oh, come now. As if I were an old man about to die..."
 
 # game/cenas/dia2/cena25.rpy:103
 translate english CENA25_23eaa03b:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena25.rpy:104
 translate english CENA25_20fb2a8c:
 
     # kmr "Me sinto na obrigação de repetir..."
-    kmr ""
+    kmr "I feel obliged to repeat..."
 
 # game/cenas/dia2/cena25.rpy:105
 translate english CENA25_ccca9ca0:
 
     # kmr "O senhor deveria parar, tio."
-    kmr ""
+    kmr "You should stop, uncle."
 
 # game/cenas/dia2/cena25.rpy:106
 translate english CENA25_ffa38559:
 
     # kmr "O senhor está doente. Estas bebidas, cigarros, noites boêmias..."
-    kmr ""
+    kmr "You're ill. These drinks, cigarettes, bohemian nights..."
 
 # game/cenas/dia2/cena25.rpy:107
 translate english CENA25_56814dd6:
 
     # kmr "Estas coisas não se encaixam mais à sua saúde."
-    kmr ""
+    kmr "These things no longer suit your health."
 
 # game/cenas/dia2/cena25.rpy:108
 translate english CENA25_8a6d77d6:
 
     # hgin "Ha ha ha. De fato."
-    hgin ""
+    hgin "Ha ha ha. Indeed."
 
 # game/cenas/dia2/cena25.rpy:109
 translate english CENA25_f10e3e8e:
 
     # hgin "Mas sabe, minha querida, não sentarei esperando a morte."
-    hgin ""
+    hgin "But you know, my dear, I won't sit around waiting for death."
 
 # game/cenas/dia2/cena25.rpy:110
 translate english CENA25_674ec85a:
 
     # hgin "Se tiver que morrer, morrerei em pé."
-    hgin ""
+    hgin "If I have to die, I'll die on my feet."
 
 # game/cenas/dia2/cena25.rpy:111
 translate english CENA25_23eaa03b_1:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena25.rpy:112
 translate english CENA25_44a24d81:
 
     # kmr "Por quê? Por que o senhor não entende?"
-    kmr ""
+    kmr "Why? Why don't you understand?"
 
 # game/cenas/dia2/cena25.rpy:113
 translate english CENA25_7146cd21:
 
     # kmr "Já te pedi muitas e muitas vezes. Mas o senhor não me ouve."
-    kmr ""
+    kmr "I've asked you so many times. But you don't listen to me."
 
 # game/cenas/dia2/cena25.rpy:114
 translate english CENA25_6efa5818:
 
     # kmr "O senhor vai morrer! Sua saúde já não suporta mais isso."
-    kmr ""
+    kmr "You're going to die! Your health can't take this anymore."
 
 # game/cenas/dia2/cena25.rpy:115
 translate english CENA25_70eb041d:
 
     # kmr "Quando você me escutará? Quando? Quando?"
-    kmr ""
+    kmr "When will you listen to me? When? When?"
 
 # game/cenas/dia2/cena25.rpy:116
 translate english CENA25_94247fea:
 
     # hgin "Já faz muito tempo que deixei de escutar a todos."
-    hgin ""
+    hgin "It's been a long time since I stopped listening to anyone."
 
 # game/cenas/dia2/cena25.rpy:117
 translate english CENA25_4e5e3668:
 
     # hgin "Aproveitarei até meu último momento."
-    hgin ""
+    hgin "I'll make the most of it until my very last moment."
 
 # game/cenas/dia2/cena25.rpy:118
 translate english CENA25_24dae18f:
 
     # kmr "O senhor não entende?"
-    kmr ""
+    kmr "Don't you understand?"
 
 # game/cenas/dia2/cena25.rpy:119
 translate english CENA25_a5de9d35:
 
     # kmr "O senhor não entende que você fará muita falta? Principalmente para mim."
-    kmr ""
+    kmr "Don't you understand that you'll be deeply missed? Especially by me."
 
 # game/cenas/dia2/cena25.rpy:120
 translate english CENA25_5b8b00ca:
 
     # kmr "Por que o senhor não me escuta?"
-    kmr ""
+    kmr "Why won't you listen to me?"
 
 # game/cenas/dia2/cena25.rpy:121
 translate english CENA25_84a0e9f5:
 
     # hgin "..."
-    hgin ""
+    hgin "..."
 
 # game/cenas/dia2/cena25.rpy:122
 translate english CENA25_2085ebb2:
 
     # hgin "Realmente me desculpe. Mas eu não posso."
-    hgin ""
+    hgin "I'm truly sorry. But I can't."
 
 # game/cenas/dia2/cena25.rpy:123
 translate english CENA25_f5566b5c:
 
     # hgin "Prefiro mil vezes morrer de corpo, do que de espírito."
-    hgin ""
+    hgin "I'd far rather die in body than in spirit."
 
 # game/cenas/dia2/cena25.rpy:124
 translate english CENA25_693ef267:
 
     # "*Kamira começa a chorar*"
-    ""
+    "*Kamira begins to cry*"
 
 # game/cenas/dia2/cena25.rpy:125
 translate english CENA25_23eaa03b_2:
 
     # kmr "..."
-    kmr ""
+    kmr "..."
 
 # game/cenas/dia2/cena25.rpy:126
 translate english CENA25_e0ee23db:
 
     # kmr "Bom, se o senhor quer assim. Então que assim seja!"
-    kmr ""
+    kmr "Well, if that's how you want it. Then so be it!"
 
 # game/cenas/dia2/cena25.rpy:133
 translate english CENA25_a20cefa7_12:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:134
 translate english CENA25_5a4c72a1_1:
 
     # "..z....sh.....zh.....sh.....z..."
-    ""
+    "..z....sh.....zh.....sh.....z..."
 
 # game/cenas/dia2/cena25.rpy:135
 translate english CENA25_374a3b23:
 
     # drc "Então era isso..."
-    drc ""
+    drc "So that was it..."
 
 # game/cenas/dia2/cena25.rpy:136
 translate english CENA25_d564cb74:
 
     # drc "..."
-    drc ""
+    drc "..."
 
 # game/cenas/dia2/cena25.rpy:137
 translate english CENA25_fa3a9346:
 
     # drc "Não acredito."
-    drc ""
+    drc "I can't believe it."
 
 # game/cenas/dia2/cena25.rpy:138
 translate english CENA25_4969a132:
 
     # drc "Ela estava preocupada com ele."
-    drc ""
+    drc "She was worried about him."
 
 # game/cenas/dia2/cena25.rpy:139
 translate english CENA25_273e9440:
 
     # drc "Com sua saúde inclusive."
-    drc ""
+    drc "About his health, even."
 
 # game/cenas/dia2/cena25.rpy:140
 translate english CENA25_765b4c80:
 
     # drc "Acho que..."
-    drc ""
+    drc "I think..."
 
 # game/cenas/dia2/cena25.rpy:142
 translate english CENA25_5a4c72a1_2:
 
     # "..z....sh.....zh.....sh.....z..."
-    ""
+    "..z....sh.....zh.....sh.....z..."
 
 # game/cenas/dia2/cena25.rpy:147
 translate english CENA25_92cc527c:
 
     # hgin "Então você voltou."
-    hgin ""
+    hgin "So you came back."
 
 # game/cenas/dia2/cena25.rpy:148
 translate english CENA25_84a0e9f5_1:
 
     # hgin "..."
-    hgin ""
+    hgin "..."
 
 # game/cenas/dia2/cena25.rpy:149
 translate english CENA25_5ca3d355:
 
     # hgin "Escondeu-se de Kamira? Pois bem... Achei muito estranho. Você nunca foi sequer dócil comigo."
-    hgin ""
+    hgin "Did you hide from Kamira? Well then... I found it very strange. You were never even gentle with me."
 
 # game/cenas/dia2/cena25.rpy:150
 translate english CENA25_8f8a8c20:
 
     # hgin "Acha que va..."
-    hgin ""
+    hgin "You think you'll..."
 
 # game/cenas/dia2/cena25.rpy:155
 translate english CENA25_d7a46183:
 
     # hgin "Argh.... Aaah.....A...... Arhc...."
-    hgin ""
+    hgin "Argh.... Aaah.....A...... Arhc...."
 
 # game/cenas/dia2/cena25.rpy:156
 translate english CENA25_8deaff75:
 
     # hgin "Cloh....... argh...... clogh..."
-    hgin ""
+    hgin "Cloh....... argh...... clogh..."
 
 # game/cenas/dia2/cena25.rpy:157
 translate english CENA25_84a0e9f5_2:
 
     # hgin "..."
-    hgin ""
+    hgin "..."
 
 # game/cenas/dia2/cena25.rpy:158
 translate english CENA25_84a0e9f5_3:
 
     # hgin "..."
-    hgin ""
+    hgin "..."
 
 # game/cenas/dia2/cena25.rpy:163
 translate english CENA25_a20cefa7_13:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:166
 translate english CENA25_d564cb74_1:
 
     # drc "..."
-    drc ""
+    drc "..."
 
 # game/cenas/dia2/cena25.rpy:167
 translate english CENA25_c3940fbf:
 
     # drc "Meu Deus..."
-    drc ""
+    drc "My God..."
 
 # game/cenas/dia2/cena25.rpy:168
 translate english CENA25_bc4ff276:
 
     # drc "Foi o momento exato."
-    drc ""
+    drc "It was the exact moment."
 
 # game/cenas/dia2/cena25.rpy:169
 translate english CENA25_26dc1a44:
 
     # "Ele não conseguiu dizer quem era."
-    ""
+    "He couldn't say who it was."
 
 # game/cenas/dia2/cena25.rpy:170
 translate english CENA25_5cef0a8f:
 
     # "Era disso que Kamira dizia mais cedo."
-    ""
+    "This is what Kamira was talking about earlier."
 
 # game/cenas/dia2/cena25.rpy:171
 translate english CENA25_527aac1e:
 
     # "Então, com isso, posso afirmar que..."
-    ""
+    "So, with this, I can state that..."
 
 # game/cenas/dia2/cena25.rpy:175
 translate english CENA25_9f654273:
 
     # "Meu Deus. Ela era inocente."
-    ""
+    "My God. She was innocent."
 
 # game/cenas/dia2/cena25.rpy:176
 translate english CENA25_b5837739:
 
     # "Por minha incompetência e falta de tato, ela se foi."
-    ""
+    "Because of my incompetence and lack of tact, she's gone."
 
 # game/cenas/dia2/cena25.rpy:177
 translate english CENA25_a20cefa7_14:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:178
 translate english CENA25_d60d67f1:
 
     # "Não. Não é hora disso. Preciso salvar os demais. Pense. Pense."
-    ""
+    "No. This is not the time for that. I need to save the others. Think. Think."
 
 # game/cenas/dia2/cena25.rpy:179
 translate english CENA25_85e6a6e4:
 
     # "Sobraram três indivíduos. Joe, Hugo e Catherine."
-    ""
+    "Three individuals remain. Joe, Hugo and Catherine."
 
 # game/cenas/dia2/cena25.rpy:180
 translate english CENA25_540fed80:
 
     # "O culpado está aqui. Dentro dessa casa. Quem será a próxima vítima?"
-    ""
+    "The culprit is here. Inside this house. Who will be the next victim?"
 
 # game/cenas/dia2/cena25.rpy:181
 translate english CENA25_a20cefa7_15:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia2/cena25.rpy:182
 translate english CENA25_cdc687e9:
 
     # "Não... não arriscaria... Só tem uma chance de se safar agora."
-    ""
+    "No... he wouldn't risk it... He has only one chance to get away now."
 
 # game/cenas/dia2/cena25.rpy:183
 translate english CENA25_4c49e61c:
 
     # "Assumo que conheça o trato com o senhor Venchinni. Aquele barulho, naquela noite, prova isso."
-    ""
+    "I assume he knows about the deal with Mr. Venchinni. That noise, that night, proves it."
 
 # game/cenas/dia2/cena25.rpy:184
 translate english CENA25_0efe9210:
 
     # "Todavia não sabe da fúria do senhor Venchinni, após a morte do senhor Sheppard, eu assumo."
-    ""
+    "However, he doesn't know about Mr. Venchinni's fury after Mr. Sheppard's death, I assume."
 
 # game/cenas/dia2/cena25.rpy:185
 translate english CENA25_333f50c8:
 
     # "Tenho o controle da situação."
-    ""
+    "I have the situation under control."
 
 # game/cenas/dia2/cena25.rpy:186
 translate english CENA25_7f0200e8:
 
     # "Por hoje descansarei. Tenho profunda certeza que o culpado não arriscaria matar outro membro da família."
-    ""
+    "For today I'll rest. I'm deeply certain the culprit wouldn't risk killing another member of the family."
 
 # game/cenas/dia2/cena25.rpy:187
 translate english CENA25_75ab55f7:
 
     # "Pela manhã, após o velório, será minha cartada final."
-    ""
+    "In the morning, after the wake, I'll make my final play."
 
 # game/cenas/dia2/cena25.rpy:188
 translate english CENA25_3cdeef03:
 
     # "É tudo ou nada."
-    ""
+    "It's all or nothing."
 
 # game/cenas/dia2/cena25.rpy:189
 translate english CENA25_e6c1ba0a:
 
     # "É só uma questão de tempo..."
-    ""
+    "It's only a matter of time..."
 
 # game/cenas/dia2/cena25.rpy:191
 translate english CENA25_a20cefa7_16:
 
     # "..."
-    ""
+    "..."
 

--- a/game/tl/english/cenas/dia3/cena31.rpy
+++ b/game/tl/english/cenas/dia3/cena31.rpy
@@ -4,161 +4,161 @@
 translate english CENA31_16965021:
 
     # "Mais um enterro foi feito. Tenho certeza que o último. Não deixarei o culpado sair impune."
-    ""
+    "Another burial has been held. The last one, I'm sure. I won't let the culprit get away."
 
 # game/cenas/dia3/cena31.rpy:5
 translate english CENA31_62a68017:
 
     # "Voltarei antes para a mansão e aguardarei todos lá."
-    ""
+    "I'll return to the mansion ahead of them and wait for everyone there."
 
 # game/cenas/dia3/cena31.rpy:29
 translate english CENA31_d66ab36a:
 
     # "Todos os três devem estar próximos. Ficarei atento a cada reação, cada detalhe..."
-    ""
+    "All three must be near. I'll watch every reaction, every detail..."
 
 # game/cenas/dia3/cena31.rpy:30
 translate english CENA31_0c898cbe:
 
     # "Catherine está entrando..."
-    ""
+    "Catherine is coming in..."
 
 # game/cenas/dia3/cena31.rpy:39
 translate english CENA31_532eb998:
 
     # drc "Meus pêsames, Catherine. Sinto-me impotente diante desses acontecimentos."
-    drc ""
+    drc "My condolences, Catherine. I feel powerless in the face of these events."
 
 # game/cenas/dia3/cena31.rpy:40
 translate english CENA31_347da4c7:
 
     # "Preciso ter calma. Observamos as reações pelas palavras. Pelas frases."
-    ""
+    "I need to stay calm. We read the reactions through the words. Through the sentences."
 
 # game/cenas/dia3/cena31.rpy:44
 translate english CENA31_767938ad:
 
     # cth "É horrível, senhor. Minha sobrinha sempre foi sensível para mortes."
-    cth ""
+    cth "It's horrible, sir. My niece was always sensitive about death."
 
 # game/cenas/dia3/cena31.rpy:45
 translate english CENA31_0644b8bb:
 
     # cth "Tirar sua própria vida desse jeito..."
-    cth ""
+    cth "To take her own life like that..."
 
 # game/cenas/dia3/cena31.rpy:46
 translate english CENA31_42814796:
 
     # cth "É algo horrivél."
-    cth ""
+    cth "It's a horrible thing."
 
 # game/cenas/dia3/cena31.rpy:47
 translate english CENA31_f0becfee:
 
     # cth "Também penso se poderia ter feito alguma coisa."
-    cth ""
+    cth "I also wonder if I could have done something."
 
 # game/cenas/dia3/cena31.rpy:48
 translate english CENA31_8803f4cd:
 
     # "Não. Ela não tirou a própria vida..."
-    ""
+    "No. She didn't take her own life..."
 
 # game/cenas/dia3/cena31.rpy:49
 translate english CENA31_311e64e3:
 
     # drc "Por que ela faria algo assim? Se soubéssemos, poderia ser diferente."
-    drc ""
+    drc "Why would she do something like that? If we had known, it could have been different."
 
 # game/cenas/dia3/cena31.rpy:50
 translate english CENA31_6b438ccc:
 
     # "Não. Não, ela não teve escolha..."
-    ""
+    "No. No, she had no choice..."
 
 # game/cenas/dia3/cena31.rpy:51
 translate english CENA31_f7a35f7d:
 
     # cth "Eu entendo. Concordo. É algo horrível."
-    cth ""
+    cth "I understand. I agree. It's a horrible thing."
 
 # game/cenas/dia3/cena31.rpy:52
 translate english CENA31_70e99cec:
 
     # cth "Por favor, senhor. Encontre o responsável pela morte de meu tio, sobrinho e pelo Sheppard."
-    cth ""
+    cth "Please, sir. Find the one responsible for the death of my uncle, my nephew and Sheppard."
 
 # game/cenas/dia3/cena31.rpy:53
 translate english CENA31_651400f5:
 
     # cth "Kamira estava desperada. Quase posso sentir o desespero dela."
-    cth ""
+    cth "Kamira was desperate. I can almost feel her despair."
 
 # game/cenas/dia3/cena31.rpy:54
 translate english CENA31_fa42b8f7:
 
     # "Sinto muito, senhorita. Não posso confiar em ninguém. Suas palavras estão vazias nesse momento. Me desculpe."
-    ""
+    "I'm sorry, miss. I can't trust anyone. Your words are empty at this moment. Forgive me."
 
 # game/cenas/dia3/cena31.rpy:55
 translate english CENA31_694b6d7d:
 
     # drc "Dou minha palavra."
-    drc ""
+    drc "I give my word."
 
 # game/cenas/dia3/cena31.rpy:56
 translate english CENA31_bf78d938:
 
     # "Só tenho mais nove horas."
-    ""
+    "I have only nine hours left."
 
 # game/cenas/dia3/cena31.rpy:57
 translate english CENA31_cccfbeb8:
 
     # drc "Encontrarei o culpado entre hoje à noite e amanhã ao amanhecer."
-    drc ""
+    drc "I will find the culprit between tonight and tomorrow's dawn."
 
 # game/cenas/dia3/cena31.rpy:58
 translate english CENA31_1383fcad:
 
     # "Não tenho esse tempo."
-    ""
+    "I don't have that much time."
 
 # game/cenas/dia3/cena31.rpy:59
 translate english CENA31_f35cf48a:
 
     # cth "Por favor, apresse-se, detetive. Talvez não tenhamos todo esse tempo."
-    cth ""
+    cth "Please hurry, detective. Maybe we don't have all that time."
 
 # game/cenas/dia3/cena31.rpy:60
 translate english CENA31_ad7074ad:
 
     # "Sim. Não temos. E que observação suspeita."
-    ""
+    "Yes. We don't. And what a suspicious remark."
 
 # game/cenas/dia3/cena31.rpy:61
 translate english CENA31_4b448937:
 
     # drc "Sim, senhorita."
-    drc ""
+    drc "Yes, miss."
 
 # game/cenas/dia3/cena31.rpy:65
 translate english CENA31_473494d6:
 
     # "Joe permanece conversando com Hugo ali fora."
-    ""
+    "Joe is still talking with Hugo out there."
 
 # game/cenas/dia3/cena31.rpy:66
 translate english CENA31_d3ab1bd2:
 
     # "Aguardarei."
-    ""
+    "I'll wait."
 
 # game/cenas/dia3/cena31.rpy:67
 translate english CENA31_ab0a6dd6:
 
     # "Mas investigarei o quarto de Joe antes. Ele estará ocupado com a conversa. Da janela de seu quarto posso ver aqui embaixo. Será seguro."
-    ""
+    "But I'll search Joe's room first. He'll be busy with the conversation. From his room's window I can see down here. It'll be safe."
 

--- a/game/tl/english/cenas/dia3/cena32.rpy
+++ b/game/tl/english/cenas/dia3/cena32.rpy
@@ -4,257 +4,257 @@
 translate english CENA32_bf7b7362:
 
     # "Perfeito. Está aberta."
-    ""
+    "Perfect. It's open."
 
 # game/cenas/dia3/cena32.rpy:4
 translate english CENA32_3fdbf89e:
 
     # "Ele deve ter esquecido com toda a confusão."
-    ""
+    "He must have forgotten with all the commotion."
 
 # game/cenas/dia3/cena32.rpy:16
 translate english CENA32_c47c2932:
 
     # "Aqui estou. Preciso encontrar algo. Algo que seja decisivo."
-    ""
+    "Here I am. I need to find something. Something decisive."
 
 # game/cenas/dia3/cena32.rpy:22
 translate english CENA32_76503ce8:
 
     # "Ok, o que conseguimos aqui..."
-    ""
+    "Okay, what do we have here..."
 
 # game/cenas/dia3/cena32.rpy:29
 translate english CENA32_162c79dc:
 
     # "Certo. Preciso abrir isso. A chave tem uma fechadura para encaixar. O problema é essa senha mecânica."
-    ""
+    "Right. I need to open this. The key has a lock to fit into. The problem is this mechanical combination."
 
 # game/cenas/dia3/cena32.rpy:30
 translate english CENA32_b721bde9:
 
     # "Esse pessoal realmente gosta de manter seus segredos guardados, e com ajuda de muita grana, porque essas coisas não são nada baratas."
-    ""
+    "These people really like to keep their secrets locked away, and with the help of a lot of money, because these things are not cheap at all."
 
 # game/cenas/dia3/cena32.rpy:31
 translate english CENA32_f5cd31bc:
 
     # "Me parece que são números. E com vários tipos de representação diferentes."
-    ""
+    "They look like numbers to me. And in several different forms of representation."
 
 # game/cenas/dia3/cena32.rpy:32
 translate english CENA32_0420e5b5:
 
     # "Preciso posicionar isso na ordem correta, aparentemente."
-    ""
+    "I need to put these in the right order, apparently."
 
 # game/cenas/dia3/cena32.rpy:33
 translate english CENA32_5bf5e1f8:
 
     # "Vamos lá."
-    ""
+    "Here goes."
 
 # game/cenas/dia3/cena32.rpy:37
 translate english CENA32_95091ce2:
 
     # "Certo. Agora giramos a chave, e..."
-    ""
+    "Right. Now we turn the key, and..."
 
 # game/cenas/dia3/cena32.rpy:42
 translate english CENA32_c2c799cf:
 
     # "Perfeito."
-    ""
+    "Perfect."
 
 # game/cenas/dia3/cena32.rpy:43
 translate english CENA32_ea411bb6:
 
     # "Vamos ver o que temos aqui."
-    ""
+    "Let's see what we have here."
 
 # game/cenas/dia3/cena32.rpy:48
 translate english CENA32_addae7f1:
 
     # "Estão molhadas."
-    ""
+    "They're wet."
 
 # game/cenas/dia3/cena32.rpy:49
 translate english CENA32_b71933f4:
 
     # "Todas elas."
-    ""
+    "All of them."
 
 # game/cenas/dia3/cena32.rpy:50
 translate english CENA32_82a3d798:
 
     # "São lágrimas."
-    ""
+    "They're tears."
 
 # game/cenas/dia3/cena32.rpy:51
 translate english CENA32_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:55
 translate english CENA32_17fafd50:
 
     # "Um desenho antigo. Talvez da infância de Joe."
-    ""
+    "An old drawing. Maybe from Joe's childhood."
 
 # game/cenas/dia3/cena32.rpy:56
 translate english CENA32_b8a17769:
 
     # "Ora. Quem diria..."
-    ""
+    "Well. Who would have thought..."
 
 # game/cenas/dia3/cena32.rpy:57
 translate english CENA32_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:58
 translate english CENA32_e3494281:
 
     # "Parece que..."
-    ""
+    "It seems that..."
 
 # game/cenas/dia3/cena32.rpy:59
 translate english CENA32_a20cefa7_2:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:60
 translate english CENA32_a20cefa7_3:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:64
 translate english CENA32_003a7689:
 
     # "Ele não saiu um minuto do lado do caixão..."
-    ""
+    "He didn't leave the side of the coffin for a minute..."
 
 # game/cenas/dia3/cena32.rpy:65
 translate english CENA32_ec26ff5d:
 
     # drc "Ora, ora..."
-    drc ""
+    drc "Well, well..."
 
 # game/cenas/dia3/cena32.rpy:66
 translate english CENA32_a20cefa7_4:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:67
 translate english CENA32_ae8498c8:
 
     # "Joe irá regressar... Preciso colocar essas coisas no lugar"
-    ""
+    "Joe will be back... I need to put these things back in place."
 
 # game/cenas/dia3/cena32.rpy:72
 translate english CENA32_b2cb9f85:
 
     # "Pronto. Agora, para meu quarto"
-    ""
+    "Done. Now, to my room."
 
 # game/cenas/dia3/cena32.rpy:105
 translate english CENA32_98c02bf7:
 
     # "Certo. Tenho que ter cautela em minhas conclusões. Mas tenho uma forte pista para inocentar Joe."
-    ""
+    "Right. I have to be cautious with my conclusions. But I have a strong clue to clear Joe."
 
 # game/cenas/dia3/cena32.rpy:106
 translate english CENA32_60bb3012:
 
     # drc "Catherine... Será você?"
-    drc ""
+    drc "Catherine... Could it be you?"
 
 # game/cenas/dia3/cena32.rpy:107
 translate english CENA32_4cc204ae:
 
     # "Preciso manter o olho nela. E falar com Hugo. Mas tenho maior suspeita em Catherine, de fato."
-    ""
+    "I need to keep an eye on her. And talk to Hugo. But I do suspect Catherine the most, in fact."
 
 # game/cenas/dia3/cena32.rpy:108
 translate english CENA32_f93045b0:
 
     # "Hugo não mostrou nenhuma atitude suspeita, desde o início. Porém..."
-    ""
+    "Hugo hasn't shown any suspicious behavior, from the start. However..."
 
 # game/cenas/dia3/cena32.rpy:109
 translate english CENA32_fb938b6b:
 
     # "Mas não posso me descuidar. Isso pode ser uma tentativa de ocultar sua presença na situação."
-    ""
+    "But I can't let my guard down. This could be an attempt to hide his involvement in the situation."
 
 # game/cenas/dia3/cena32.rpy:110
 translate english CENA32_7b7c19ce:
 
     # "Isso é realmente muito estranho. Vou provocá-lo assim como fiz com Catherine."
-    ""
+    "This really is very strange. I'll provoke him just as I did with Catherine."
 
 # game/cenas/dia3/cena32.rpy:115
 translate english CENA32_9c9050d6:
 
     # "Deve ser Joe, voltando para o quarto."
-    ""
+    "That must be Joe, coming back to the room."
 
 # game/cenas/dia3/cena32.rpy:116
 translate english CENA32_23b87cab:
 
     # "Tenho pressa, mas preciso ser cuidadoso. Ficarei aqui por um tempo, para evitar suspeitas."
-    ""
+    "I'm in a hurry, but I need to be careful. I'll stay here a while, to avoid suspicion."
 
 # game/cenas/dia3/cena32.rpy:117
 translate english CENA32_cd7ed701:
 
     # "Alguns de meus colegas de serviço poderiam pensar que esta é uma decisão tola. Esperar em meio a uma corrida contra o tempo."
-    ""
+    "Some of my colleagues in the trade might think this is a foolish decision. To wait in the middle of a race against time."
 
 # game/cenas/dia3/cena32.rpy:118
 translate english CENA32_a20cefa7_5:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena32.rpy:119
 translate english CENA32_a14657f1:
 
     # "Mas esses meus colegas não viram duas pessoas serem assassinadas em frente a seus narizes."
-    ""
+    "But these colleagues of mine didn't watch two people be murdered right under their noses."
 
 # game/cenas/dia3/cena32.rpy:120
 translate english CENA32_7f5b0a3c:
 
     # "O assassino sabe o que faz. É inteligente. Excepcionalmente inteligente."
-    ""
+    "The murderer knows what he's doing. He's intelligent. Exceptionally intelligent."
 
 # game/cenas/dia3/cena32.rpy:121
 translate english CENA32_4c062788:
 
     # "Tempo é crucial, quando a cautela não é necessária."
-    ""
+    "Time is crucial, when caution isn't needed."
 
 # game/cenas/dia3/cena32.rpy:122
 translate english CENA32_bbe5cad8:
 
     # "Preciso ser paciente."
-    ""
+    "I need to be patient."
 
 # game/cenas/dia3/cena32.rpy:123
 translate english CENA32_31cb8881:
 
     # "Cada ato será fundamental. Irreversível. Calma. Preciso de calma."
-    ""
+    "Every act will be critical. Irreversible. Calm. I need to stay calm."
 
 # game/cenas/dia3/cena32.rpy:124
 translate english CENA32_a20cefa7_6:
 
     # "..."
-    ""
+    "..."
 

--- a/game/tl/english/cenas/dia3/cena33.rpy
+++ b/game/tl/english/cenas/dia3/cena33.rpy
@@ -4,923 +4,923 @@
 translate english CENA33_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:7
 translate english CENA33_9f007043:
 
     # "Acho que me restou uma última pista útil..."
-    ""
+    "I think I have one last useful clue left..."
 
 # game/cenas/dia3/cena33.rpy:8
 translate english CENA33_edd0a713:
 
     # "Sinto um cheiro diferente dela."
-    ""
+    "I smell a strange scent coming from it."
 
 # game/cenas/dia3/cena33.rpy:12
 translate english CENA33_04d27c28:
 
     # "Exatamente, o lenço do senhor Sheppard."
-    ""
+    "Exactly, Mr. Sheppard's handkerchief."
 
 # game/cenas/dia3/cena33.rpy:13
 translate english CENA33_6131e645:
 
     # "O que é isso dentro dele?"
-    ""
+    "What is this inside it?"
 
 # game/cenas/dia3/cena33.rpy:17
 translate english CENA33_d0c9305d:
 
     # "Entendo..."
-    ""
+    "I see..."
 
 # game/cenas/dia3/cena33.rpy:18
 translate english CENA33_bc161b6c:
 
     # "Então era isso."
-    ""
+    "So that was it."
 
 # game/cenas/dia3/cena33.rpy:19
 translate english CENA33_b66494a6:
 
     # "Como pude não perceber?"
-    ""
+    "How could I not have noticed?"
 
 # game/cenas/dia3/cena33.rpy:21
 translate english CENA33_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:22
 translate english CENA33_85e8f827:
 
     # "Verei Hugo primeiro."
-    ""
+    "I'll see Hugo first."
 
 # game/cenas/dia3/cena33.rpy:23
 translate english CENA33_baae4786:
 
     # "Ele deve estar lá embaixo."
-    ""
+    "He must be downstairs."
 
 # game/cenas/dia3/cena33.rpy:45
 translate english CENA33_00e0a899:
 
     # "Claro..."
-    ""
+    "Of course..."
 
 # game/cenas/dia3/cena33.rpy:48
 translate english CENA33_56cbc993:
 
     # "Deixe me retirar isso..."
-    ""
+    "Let me take this out..."
 
 # game/cenas/dia3/cena33.rpy:51
 translate english CENA33_312f8c1e:
 
     # "Pronto."
-    ""
+    "Done."
 
 # game/cenas/dia3/cena33.rpy:54
 translate english CENA33_5bf5e1f8:
 
     # "Vamos lá."
-    ""
+    "Here goes."
 
 # game/cenas/dia3/cena33.rpy:60
 translate english CENA33_517f88d7:
 
     # "Ali está ele."
-    ""
+    "There he is."
 
 # game/cenas/dia3/cena33.rpy:61
 translate english CENA33_f6429198:
 
     # drc "Senhor Hugo."
-    drc ""
+    drc "Mr. Hugo."
 
 # game/cenas/dia3/cena33.rpy:65
 translate english CENA33_ed4790b4:
 
     # hugo "Senhor Rightclue! Estamos destruídos. Não conseguimos mais aguentar ver pessoas queridas morrerem."
-    hugo ""
+    hugo "Mr. Rightclue! We're devastated. We can't bear to watch our loved ones die anymore."
 
 # game/cenas/dia3/cena33.rpy:66
 translate english CENA33_9f5c258b:
 
     # drc "Eu entendo."
-    drc ""
+    drc "I understand."
 
 # game/cenas/dia3/cena33.rpy:67
 translate english CENA33_3d0e747c:
 
     # drc "Prometo resolver esse caso até amanhã de manhã, no mais tardar."
-    drc ""
+    drc "I promise to solve this case by tomorrow morning, at the latest."
 
 # game/cenas/dia3/cena33.rpy:68
 translate english CENA33_a8485871:
 
     # hugo "O senhor continua dizendo isso, mas veja como estamos..."
-    hugo ""
+    hugo "You keep saying that, but look at the state we're in..."
 
 # game/cenas/dia3/cena33.rpy:69
 translate english CENA33_7cae596d:
 
     # hugo "Mesmo assim, fico grato em ouvir isso. Só temo pela nossa segurança esta noite."
-    hugo ""
+    hugo "Even so, I'm grateful to hear it. I just fear for our safety tonight."
 
 # game/cenas/dia3/cena33.rpy:70
 translate english CENA33_d1ab4ff5:
 
     # drc "Fique tranquilo, pois já tenho quase certeza de quem se trata."
-    drc ""
+    drc "Rest easy, for I'm now almost certain of who it is."
 
 # game/cenas/dia3/cena33.rpy:74
 translate english CENA33_75e622e7:
 
     # hugo "Já sabe? Mas o que o senhor está esperando?"
-    hugo ""
+    hugo "You already know? Then what are you waiting for?"
 
 # game/cenas/dia3/cena33.rpy:78
 translate english CENA33_fda7c470:
 
     # drc "Preciso ter certeza, senhor Hugo."
-    drc ""
+    drc "I need to be certain, Mr. Hugo."
 
 # game/cenas/dia3/cena33.rpy:82
 translate english CENA33_18dd126e:
 
     # hugo "Certeza, senhor Rightclue? Estamos morrendo, um a um, e o senhor me diz calma?!"
-    hugo ""
+    hugo "Certain, Mr. Rightclue? We're dying, one by one, and you tell me to stay calm?!"
 
 # game/cenas/dia3/cena33.rpy:86
 translate english CENA33_3d72d3fd:
 
     # "Ele está agitado. O que normalmente não acontece."
-    ""
+    "He's agitated. Which doesn't usually happen."
 
 # game/cenas/dia3/cena33.rpy:87
 translate english CENA33_0416ea0c:
 
     # drc "Dou minha palavra. O culpado não agirá hoje. Não há o que temer."
-    drc ""
+    drc "I give my word. The culprit won't act today. There's nothing to fear."
 
 # game/cenas/dia3/cena33.rpy:88
 translate english CENA33_2d2a6b8f:
 
     # hugo "Senhor Rightclue, não gostaria de dizer isso levianamente. Mas creio que a morte de Kamira não foi suicídio."
-    hugo ""
+    hugo "Mr. Rightclue, I wouldn't want to say this lightly. But I believe Kamira's death was not suicide."
 
 # game/cenas/dia3/cena33.rpy:89
 translate english CENA33_bfd56064:
 
     # drc "Como assim, Hugo? Me conte."
-    drc ""
+    drc "What do you mean, Hugo? Tell me."
 
 # game/cenas/dia3/cena33.rpy:90
 translate english CENA33_8788a7b2:
 
     # hugo "Creio que ela foi assassinada, detetive."
-    hugo ""
+    hugo "I believe she was murdered, detective."
 
 # game/cenas/dia3/cena33.rpy:91
 translate english CENA33_b95e2291:
 
     # drc "Mas ela estava enforcada. O senhor insinua que foi uma cena armada?"
-    drc ""
+    drc "But she was hanged. Are you suggesting the scene was staged?"
 
 # game/cenas/dia3/cena33.rpy:92
 translate english CENA33_665e841f:
 
     # hugo "Exato. Tenho suspeita de uma pessoa, com quem conversei agora há pouco."
-    hugo ""
+    hugo "Exactly. I suspect a certain person, whom I spoke with just now."
 
 # game/cenas/dia3/cena33.rpy:93
 translate english CENA33_a4b1ba6a:
 
     # "Catherine, não é?"
-    ""
+    "Catherine, isn't it?"
 
 # game/cenas/dia3/cena33.rpy:94
 translate english CENA33_d3d3c16a:
 
     # drc "Obrigado pela informação, Hugo. Peço que, se possível, vá para seu quarto."
-    drc ""
+    drc "Thank you for the information, Hugo. I ask that, if possible, you go to your room."
 
 # game/cenas/dia3/cena33.rpy:95
 translate english CENA33_5a757f0b:
 
     # hugo "Detetive, e qual seria a finalidade?"
-    hugo ""
+    hugo "Detective, and what would be the purpose?"
 
 # game/cenas/dia3/cena33.rpy:96
 translate english CENA33_e5aac896:
 
     # drc "Eu tenho um assunto a resolver."
-    drc ""
+    drc "I have a matter to settle."
 
 # game/cenas/dia3/cena33.rpy:97
 translate english CENA33_5eead76b:
 
     # drc "Há algo grande envolvido. Por favor, confie em mim. É para sua segurança."
-    drc ""
+    drc "There's something big at stake. Please, trust me. It's for your safety."
 
 # game/cenas/dia3/cena33.rpy:98
 translate english CENA33_aa9fa408:
 
     # drc "Se o senhor não tiver ao que se opor, é claro."
-    drc ""
+    drc "If you have no objection, of course."
 
 # game/cenas/dia3/cena33.rpy:99
 translate english CENA33_77255a03:
 
     # hugo "Não."
-    hugo ""
+    hugo "No."
 
 # game/cenas/dia3/cena33.rpy:100
 translate english CENA33_b3e442b6:
 
     # hugo "Está bem. Assim farei."
-    hugo ""
+    hugo "All right. I'll do that."
 
 # game/cenas/dia3/cena33.rpy:101
 translate english CENA33_e028c429:
 
     # drc "Conto com você."
-    drc ""
+    drc "I'm counting on you."
 
 # game/cenas/dia3/cena33.rpy:102
 translate english CENA33_a20cefa7_2:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:107
 translate english CENA33_a20cefa7_3:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:108
 translate english CENA33_f9de1cdf:
 
     # "É agora."
-    ""
+    "It's now."
 
 # game/cenas/dia3/cena33.rpy:109
 translate english CENA33_a90a41bd:
 
     # "Catherine está vindo."
-    ""
+    "Catherine is coming."
 
 # game/cenas/dia3/cena33.rpy:110
 translate english CENA33_547f703b:
 
     # "Preciso agir."
-    ""
+    "I need to act."
 
 # game/cenas/dia3/cena33.rpy:111
 translate english CENA33_cdb19f7c:
 
     # "E terei que ser rápido para a captura."
-    ""
+    "And I'll have to be quick for the capture."
 
 # game/cenas/dia3/cena33.rpy:112
 translate english CENA33_a20cefa7_4:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:117
 translate english CENA33_575cff3e:
 
     # cth "Senhor Rightclue."
-    cth ""
+    cth "Mr. Rightclue."
 
 # game/cenas/dia3/cena33.rpy:118
 translate english CENA33_a20cefa7_5:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:119
 translate english CENA33_1a102263:
 
     # drc "Olá, Catherine."
-    drc ""
+    drc "Hello, Catherine."
 
 # game/cenas/dia3/cena33.rpy:120
 translate english CENA33_412014b6:
 
     # cth "O senhor parece furioso."
-    cth ""
+    cth "You look furious."
 
 # game/cenas/dia3/cena33.rpy:121
 translate english CENA33_c4800a73:
 
     # cth "Não parece ser de seu feitio."
-    cth ""
+    cth "It doesn't seem like you."
 
 # game/cenas/dia3/cena33.rpy:122
 translate english CENA33_439dcf81:
 
     # drc "De fato."
-    drc ""
+    drc "Indeed."
 
 # game/cenas/dia3/cena33.rpy:123
 translate english CENA33_3e60dd24:
 
     # drc "Catherine, deixe-me pedir uma coisa a você."
-    drc ""
+    drc "Catherine, let me ask something of you."
 
 # game/cenas/dia3/cena33.rpy:124
 translate english CENA33_c1e9290b:
 
     # cth "E o que seria, senhor?"
-    cth ""
+    cth "And what would that be, sir?"
 
 # game/cenas/dia3/cena33.rpy:125
 translate english CENA33_d564cb74:
 
     # drc "..."
-    drc ""
+    drc "..."
 
 # game/cenas/dia3/cena33.rpy:129
 translate english CENA33_aa932df3:
 
     # drc "Você poderia me acompanhar?"
-    drc ""
+    drc "Could you come with me?"
 
 # game/cenas/dia3/cena33.rpy:130
 translate english CENA33_d78d0193:
 
     # cth "E por que desse pedido?"
-    cth ""
+    cth "And why this request?"
 
 # game/cenas/dia3/cena33.rpy:131
 translate english CENA33_cc00f744:
 
     # drc "Por favor, venha."
-    drc ""
+    drc "Please, come."
 
 # game/cenas/dia3/cena33.rpy:132
 translate english CENA33_828555c8:
 
     # cth "..."
-    cth ""
+    cth "..."
 
 # game/cenas/dia3/cena33.rpy:133
 translate english CENA33_58c64cca:
 
     # cth "Certo."
-    cth ""
+    cth "All right."
 
 # game/cenas/dia3/cena33.rpy:150
 translate english CENA33_662b6a0f:
 
     # cth "Algum problema com o quarto do Hugo, senhor?."
-    cth ""
+    cth "Is there some problem with Hugo's room, sir?"
 
 # game/cenas/dia3/cena33.rpy:151
 translate english CENA33_22cd7173:
 
     # drc "Olhe."
-    drc ""
+    drc "Look."
 
 # game/cenas/dia3/cena33.rpy:156
 translate english CENA33_b7646546:
 
     # cth "O que é isso, detetive?"
-    cth ""
+    cth "What is this, detective?"
 
 # game/cenas/dia3/cena33.rpy:157
 translate english CENA33_d564cb74_1:
 
     # drc "..."
-    drc ""
+    drc "..."
 
 # game/cenas/dia3/cena33.rpy:161
 translate english CENA33_644b8e40:
 
     # drc "Pelo de cachorro."
-    drc ""
+    drc "Dog hair."
 
 # game/cenas/dia3/cena33.rpy:165
 translate english CENA33_d7b8eb03:
 
     # "Simples fios. Alguns cabelos. Porém, mais grossos."
-    ""
+    "Simple strands. Some hairs. But thicker."
 
 # game/cenas/dia3/cena33.rpy:166
 translate english CENA33_b8482da2:
 
     # "Um detalhe. Desprezei. Não há por que se atentar a isso."
-    ""
+    "A detail. I dismissed it. There was no reason to pay attention to it."
 
 # game/cenas/dia3/cena33.rpy:167
 translate english CENA33_bcdaace4:
 
     # "A menos que..."
-    ""
+    "Unless..."
 
 # game/cenas/dia3/cena33.rpy:168
 translate english CENA33_28724797:
 
     # "Que não fossem cabelos."
-    ""
+    "That they weren't hairs."
 
 # game/cenas/dia3/cena33.rpy:169
 translate english CENA33_e37d62ba:
 
     # "Ninguém tem um cabelo tão grosso. Mas isso não é discriminante. Pelo menos não foi na hora."
-    ""
+    "No one has hair that thick. But that's not conclusive. At least it wasn't at the time."
 
 # game/cenas/dia3/cena33.rpy:170
 translate english CENA33_73e8078f:
 
     # "Um dia se passou. O suficiente para o cheiro do animal se sobressair..."
-    ""
+    "A day went by. Enough for the animal's scent to stand out..."
 
 # game/cenas/dia3/cena33.rpy:171
 translate english CENA33_11cfbdfd:
 
     # "... por alguns pelos."
-    ""
+    "... through a few hairs."
 
 # game/cenas/dia3/cena33.rpy:181
 translate english CENA33_55493b80:
 
     # hugo "O que é isso? Quem está ai? Quem trancou a porta?"
-    hugo ""
+    hugo "What is this? Who's there? Who locked the door?"
 
 # game/cenas/dia3/cena33.rpy:182
 translate english CENA33_a20cefa7_6:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena33.rpy:186
 translate english CENA33_be095a17:
 
     # drc "Seu maldito..."
-    drc ""
+    drc "You wretch..."
 
 # game/cenas/dia3/cena33.rpy:187
 translate english CENA33_dec47bb9:
 
     # drc "Como pôde? Fazer isso com seu próprio pai?!"
-    drc ""
+    drc "How could you? Do this to your own father?!"
 
 # game/cenas/dia3/cena33.rpy:188
 translate english CENA33_39adc109:
 
     # drc "Com seu próprio tio."
-    drc ""
+    drc "To your own uncle."
 
 # game/cenas/dia3/cena33.rpy:189
 translate english CENA33_f1a15c41:
 
     # drc "Com aquele que ajudou a te criar dentro dessa casa."
-    drc ""
+    drc "To the one who helped raise you in this house."
 
 # game/cenas/dia3/cena33.rpy:190
 translate english CENA33_0b6c5a07:
 
     # drc "Com sua própria prima."
-    drc ""
+    drc "To your own cousin."
 
 # game/cenas/dia3/cena33.rpy:191
 translate english CENA33_ff617019:
 
     # drc "Você não tem alma."
-    drc ""
+    drc "You have no soul."
 
 # game/cenas/dia3/cena33.rpy:192
 translate english CENA33_1e2d6427:
 
     # hugo "Do que o senhor está falando?"
-    hugo ""
+    hugo "What are you talking about?"
 
 # game/cenas/dia3/cena33.rpy:193
 translate english CENA33_83209e16:
 
     # hugo "Por favor, eu não fiz nada."
-    hugo ""
+    hugo "Please, I didn't do anything."
 
 # game/cenas/dia3/cena33.rpy:194
 translate english CENA33_cc9bb02e:
 
     # drc "Cale a boca!"
-    drc ""
+    drc "Shut your mouth!"
 
 # game/cenas/dia3/cena33.rpy:195
 translate english CENA33_f921403b:
 
     # drc "Mentira."
-    drc ""
+    drc "Lies."
 
 # game/cenas/dia3/cena33.rpy:202
 translate english CENA33_821bb91b:
 
     # cth "Senhor Rightclue..."
-    cth ""
+    cth "Mr. Rightclue..."
 
 # game/cenas/dia3/cena33.rpy:209
 translate english CENA33_43b1f3a4:
 
     # drc "Esse maldito tentou te acusar. Há menos de dez minutos."
-    drc ""
+    drc "This wretch tried to accuse you. Less than ten minutes ago."
 
 # game/cenas/dia3/cena33.rpy:210
 translate english CENA33_6a0cfd49:
 
     # drc "É um canalha! Sem coração, podre até o espírito."
-    drc ""
+    drc "He's a scoundrel! Heartless, rotten to the very soul."
 
 # game/cenas/dia3/cena33.rpy:211
 translate english CENA33_3319dd2e:
 
     # hugo "Não! Não fui eu!"
-    hugo ""
+    hugo "No! It wasn't me!"
 
 # game/cenas/dia3/cena33.rpy:218
 translate english CENA33_8e596697:
 
     # cth "Senhor Rightclue! Eu não acredito. Não pode ser."
-    cth ""
+    cth "Mr. Rightclue! I can't believe it. It can't be."
 
 # game/cenas/dia3/cena33.rpy:219
 translate english CENA33_d9afcc4e:
 
     # cth "Hugo não faria isso. Por favor, deixe-o ir!"
-    cth ""
+    cth "Hugo wouldn't do this. Please, let him go!"
 
 # game/cenas/dia3/cena33.rpy:226
 translate english CENA33_100728c3:
 
     # drc "Você é a pior escória."
-    drc ""
+    drc "You're the worst kind of scum."
 
 # game/cenas/dia3/cena33.rpy:227
 translate english CENA33_c51c30f1:
 
     # drc "Um lixo. Uma praga."
-    drc ""
+    drc "Garbage. A plague."
 
 # game/cenas/dia3/cena33.rpy:235
 translate english CENA33_9f19ae46:
 
     # cth "Por favor, Senhor Rightclue, não foi ele!"
-    cth ""
+    cth "Please, Mr. Rightclue, it wasn't him!"
 
 # game/cenas/dia3/cena33.rpy:240
 translate english CENA33_47f23603:
 
     # joe "O que está acontecendo aqui?"
-    joe ""
+    joe "What's going on here?"
 
 # game/cenas/dia3/cena33.rpy:241
 translate english CENA33_4cdd67af:
 
     # drc "Ora, boa noite, Joe."
-    drc ""
+    drc "Well, good evening, Joe."
 
 # game/cenas/dia3/cena33.rpy:242
 translate english CENA33_8cc3944e:
 
     # drc "Acabo de prender o maldito traidor."
-    drc ""
+    drc "I've just captured the damned traitor."
 
 # game/cenas/dia3/cena33.rpy:243
 translate english CENA33_257f2831:
 
     # joe "Isso é um absurdo! Hugo jamais faria isso."
-    joe ""
+    joe "This is absurd! Hugo would never do this."
 
 # game/cenas/dia3/cena33.rpy:244
 translate english CENA33_284e12a8:
 
     # drc "Todos achavam. Eu achava. Mas não passou de uma armação."
-    drc ""
+    drc "Everyone thought so. I thought so. But it was nothing but a setup."
 
 # game/cenas/dia3/cena33.rpy:252
 translate english CENA33_7c163809:
 
     # drc "Sentiu-se bem ao matar o homem que foi leal a sua família?"
-    drc ""
+    drc "Did it feel good to kill the man who was loyal to your family?"
 
 # game/cenas/dia3/cena33.rpy:253
 translate english CENA33_ff6249f9:
 
     # drc "E o que sentiu quando viu sua prima morrer enforcada diante de seus olhos, seu canalha?"
-    drc ""
+    drc "And how did it feel when you watched your cousin die, hanged before your eyes, you scoundrel?"
 
 # game/cenas/dia3/cena33.rpy:254
 translate english CENA33_964cddee:
 
     # drc "Você deveria ser estirpado da face da terra."
-    drc ""
+    drc "You should be wiped from the face of the earth."
 
 # game/cenas/dia3/cena33.rpy:255
 translate english CENA33_cc7320a4:
 
     # hugo "Por favor, eu não fiz nada!"
-    hugo ""
+    hugo "Please, I didn't do anything!"
 
 # game/cenas/dia3/cena33.rpy:256
 translate english CENA33_6e3bbe3b:
 
     # hugo "Tia, Joe, por favor! Ele está louco!"
-    hugo ""
+    hugo "Auntie, Joe, please! He's gone mad!"
 
 # game/cenas/dia3/cena33.rpy:257
 translate english CENA33_cc9bb02e_1:
 
     # drc "Cale a boca!"
-    drc ""
+    drc "Shut your mouth!"
 
 # game/cenas/dia3/cena33.rpy:258
 translate english CENA33_8291e8c4:
 
     # drc "E cale agora! Seu maldito! Se acha mais inteligente do que eu?"
-    drc ""
+    drc "And shut up now! You wretch! You think you're smarter than me?"
 
 # game/cenas/dia3/cena33.rpy:259
 translate english CENA33_d0bcd533:
 
     # drc "A ponto de armar todo esse esquema?"
-    drc ""
+    drc "Enough to set up this whole scheme?"
 
 # game/cenas/dia3/cena33.rpy:260
 translate english CENA33_faf8c8e7:
 
     # drc "Catherine brada o mais alto aqui para te libertar. Você também faria isso? Canalha! Sabe que Carlo virá buscá-lo."
-    drc ""
+    drc "Catherine cries out the loudest here to set you free. Would you do the same? Scoundrel! You know Carlo will come for you."
 
 # game/cenas/dia3/cena33.rpy:261
 translate english CENA33_f8b7ee53:
 
     # drc "Acha que não percebi quando você se aproximou no velório do senhor Sheppard? Sorrateiramente, escutou toda a conversa."
-    drc ""
+    drc "You think I didn't notice when you crept close at Mr. Sheppard's wake? Sneakily, you listened to the whole conversation."
 
 # game/cenas/dia3/cena33.rpy:262
 translate english CENA33_ea11e02a:
 
     # drc "Não me matou porque sabia que a polícia se envolveria."
-    drc ""
+    drc "You didn't kill me because you knew the police would get involved."
 
 # game/cenas/dia3/cena33.rpy:263
 translate english CENA33_8c94bbda:
 
     # drc "Sabia que o senhor Sheppard conhecia a todos muito bem, ele notaria quaisquer coisas diferente."
-    drc ""
+    drc "You knew Mr. Sheppard knew everyone very well; he would notice anything out of place."
 
 # game/cenas/dia3/cena33.rpy:264
 translate english CENA33_feedfe99:
 
     # drc "Chegaríamos a você em um piscar de olhos."
-    drc ""
+    drc "We'd have reached you in the blink of an eye."
 
 # game/cenas/dia3/cena33.rpy:265
 translate english CENA33_c46f2ea9:
 
     # drc "Você não presta."
-    drc ""
+    drc "You're no good."
 
 # game/cenas/dia3/cena33.rpy:266
 translate english CENA33_7ecccc5f:
 
     # drc "Precisava incriminar alguém, sabia disso. E estava desesperado."
-    drc ""
+    drc "You needed to frame someone, you knew that. And you were desperate."
 
 # game/cenas/dia3/cena33.rpy:267
 translate english CENA33_6cff589b:
 
     # drc "Matou Kamira e fez parecer um suicídio, pois não queria chamar mais atenção. Ela sabia de algumas coisas e colaboraria comigo."
-    drc ""
+    drc "You killed Kamira and made it look like a suicide, because you didn't want to draw more attention. She knew certain things and would have cooperated with me."
 
 # game/cenas/dia3/cena33.rpy:268
 translate english CENA33_156bbfd8:
 
     # drc "Kamira amava seu tio como se fosse seu próprio pai, brigaram na noite de sua morte por exigir que ele se cuidasse mais."
-    drc ""
+    drc "Kamira loved her uncle as if he were her own father; they argued the night he died because she demanded he take better care of himself."
 
 # game/cenas/dia3/cena33.rpy:269
 translate english CENA33_c52bf7cd:
 
     # drc "Ela jamais seria capaz de cometer uma atrocidade desse tipo."
-    drc ""
+    drc "She would never be capable of committing an atrocity like this."
 
 # game/cenas/dia3/cena33.rpy:270
 translate english CENA33_58dc8a69:
 
     # hugo "..."
-    hugo ""
+    hugo "..."
 
 # game/cenas/dia3/cena33.rpy:271
 translate english CENA33_b573daf9:
 
     # drc "Reponda, seu desgraçado!"
-    drc ""
+    drc "Answer me, you wretch!"
 
 # game/cenas/dia3/cena33.rpy:272
 translate english CENA33_b927546c:
 
     # drc "Temos um faltando, não é?"
-    drc ""
+    drc "We have one missing, don't we?"
 
 # game/cenas/dia3/cena33.rpy:273
 translate english CENA33_a74ab035:
 
     # drc "Joe. E quanto ao Joe?"
-    drc ""
+    drc "Joe. What about Joe?"
 
 # game/cenas/dia3/cena33.rpy:274
 translate english CENA33_d143e28b:
 
     # drc "Ele não mataria o senhor Sheppard. Jamais. Sheppard cuidou dele. Ele o amava como pai. Estou errado Joe?"
-    drc ""
+    drc "He wouldn't kill Mr. Sheppard. Never. Sheppard took care of him. He loved him like a father. Am I wrong, Joe?"
 
 # game/cenas/dia3/cena33.rpy:282
 translate english CENA33_9891dc61:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia3/cena33.rpy:283
 translate english CENA33_e250b0f9:
 
     # joe "Não posso acreditar..."
-    joe ""
+    joe "I can't believe it..."
 
 # game/cenas/dia3/cena33.rpy:284
 translate english CENA33_5de248d5:
 
     # cth "O que está acontecendo...? Meu Deus..."
-    cth ""
+    cth "What is happening...? My God..."
 
 # game/cenas/dia3/cena33.rpy:292
 translate english CENA33_782130d5:
 
     # drc "Você vai apodrecer sem nem um tostão, seu maldito."
-    drc ""
+    drc "You'll rot without a single penny, you wretch."
 
 # game/cenas/dia3/cena33.rpy:293
 translate english CENA33_58dc8a69_1:
 
     # hugo "..."
-    hugo ""
+    hugo "..."
 
 # game/cenas/dia3/cena33.rpy:294
 translate english CENA33_39fecadb:
 
     # hugo "Ha...Ha ha..."
-    hugo ""
+    hugo "Ha...Ha ha..."
 
 # game/cenas/dia3/cena33.rpy:300
 translate english CENA33_03fdd59c:
 
     # hugo "HAHAHAHAHAHAHAHAHAHA"
-    hugo ""
+    hugo "HAHAHAHAHAHAHAHAHAHA"
 
 # game/cenas/dia3/cena33.rpy:301
 translate english CENA33_af0520f0:
 
     # hugo "Genial. Genial, detetive! Você é mesmo surpreendente! Hahahahaha!"
-    hugo ""
+    hugo "Brilliant. Brilliant, detective! You really are astonishing! Hahahahaha!"
 
 # game/cenas/dia3/cena33.rpy:302
 translate english CENA33_8a34b8b6:
 
     # hugo "Abra essa porta, seu covarde!"
-    hugo ""
+    hugo "Open this door, you coward!"
 
 # game/cenas/dia3/cena33.rpy:303
 translate english CENA33_e2359e32:
 
     # hugo "Me enfrente cara a cara!"
-    hugo ""
+    hugo "Face me face to face!"
 
 # game/cenas/dia3/cena33.rpy:304
 translate english CENA33_ccd5a009:
 
     # drc "Cale a boca, seu verme!"
-    drc ""
+    drc "Shut up, you worm!"
 
 # game/cenas/dia3/cena33.rpy:305
 translate english CENA33_2bd8ff93:
 
     # drc "Seu destino já está traçado."
-    drc ""
+    drc "Your fate is already sealed."
 
 # game/cenas/dia3/cena33.rpy:313
 translate english CENA33_e4c199a3:
 
     # joe "Detetive..."
-    joe ""
+    joe "Detective..."
 
 # game/cenas/dia3/cena33.rpy:318
 translate english CENA33_db6c4df2:
 
     # joe "Detetive, abra essa porta. Eu mesmo vou matar esse desgraçado!"
-    joe ""
+    joe "Detective, open this door. I'll kill this wretch myself!"
 
 # game/cenas/dia3/cena33.rpy:319
 translate english CENA33_06fa9b56:
 
     # joe "Abra essa maldita porta!"
-    joe ""
+    joe "Open this damned door!"
 
 # game/cenas/dia3/cena33.rpy:321
 translate english CENA33_a9aeb051:
 
     # drc "Joe. Não. Carlo Venchinni virá buscá-lo. Se não entregarmos esse maldito, ele matará vocês dois também."
-    drc ""
+    drc "Joe. No. Carlo Venchinni will come for him. If we don't hand this wretch over, he'll kill you both too."
 
 # game/cenas/dia3/cena33.rpy:323
 translate english CENA33_d01eb690:
 
     # joe "Mas que merda!"
-    joe ""
+    joe "What the hell!"
 
 # game/cenas/dia3/cena33.rpy:324
 translate english CENA33_bc39221c:
 
     # joe "Hugo, eu vou te matar!"
-    joe ""
+    joe "Hugo, I'm going to kill you!"
 
 # game/cenas/dia3/cena33.rpy:325
 translate english CENA33_19251470:
 
     # hugo "Pois tente, querido irmão!"
-    hugo ""
+    hugo "Then try, dear brother!"
 
 # game/cenas/dia3/cena33.rpy:326
 translate english CENA33_10cd9482:
 
     # joe "AAAAAAAAAAAAAAAHHHHHHHH!!!"
-    joe ""
+    joe "AAAAAAAAAAAAAAAHHHHHHHH!!!"
 
 # game/cenas/dia3/cena33.rpy:332
 translate english CENA33_4d6b732b:
 
     # drc "Joe! Não quebre a porta."
-    drc ""
+    drc "Joe! Don't break the door."
 
 # game/cenas/dia3/cena33.rpy:333
 translate english CENA33_7289c135:
 
     # drc "Vou ligar para o senhor Venchinni."
-    drc ""
+    drc "I'm going to call Mr. Venchinni."
 
 # game/cenas/dia3/cena33.rpy:334
 translate english CENA33_303e3c21:
 
     # drc "Joe. Não abra. Me prometa. Não abra."
-    drc ""
+    drc "Joe. Don't open it. Promise me. Don't open it."
 
 # game/cenas/dia3/cena33.rpy:335
 translate english CENA33_2ee2ebe2:
 
     # drc "Eu vou salvar vocês. Eu jurei para o senhor Sheppard, e para mim mesmo, depois da morte dele."
-    drc ""
+    drc "I'm going to save you. I swore to Mr. Sheppard, and to myself, after his death."
 
 # game/cenas/dia3/cena33.rpy:340
 translate english CENA33_3702db9f:
 
     # joe "Eu vou matá-lo."
-    joe ""
+    joe "I'm going to kill him."
 
 # game/cenas/dia3/cena33.rpy:341
 translate english CENA33_be21407b:
 
     # drc "Joe! Pense na Catherine. Venchinni irá matá-la também."
-    drc ""
+    drc "Joe! Think of Catherine. Venchinni will kill her too."
 
 # game/cenas/dia3/cena33.rpy:342
 translate english CENA33_9891dc61_1:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia3/cena33.rpy:343
 translate english CENA33_f161b89e:
 
     # hugo "Abram esse porta, seus malditos. Vou matar todos vocês."
-    hugo ""
+    hugo "Open this door, you wretches. I'll kill every one of you."
 
 # game/cenas/dia3/cena33.rpy:344
 translate english CENA33_9891dc61_2:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia3/cena33.rpy:345
 translate english CENA33_863c43b9:
 
     # drc "Certo."
-    drc ""
+    drc "All right."
 

--- a/game/tl/english/cenas/dia3/cena34.rpy
+++ b/game/tl/english/cenas/dia3/cena34.rpy
@@ -4,515 +4,515 @@
 translate english CENA34_43a592cf:
 
     # hugo "Meus parabéns, seu maldito! Salvou o dia. Desgraçado!"
-    hugo ""
+    hugo "Congratulations, you wretch! You saved the day. Bastard!"
 
 # game/cenas/dia3/cena34.rpy:11
 translate english CENA34_43e19b91:
 
     # hugo "Se não fosse por você e Sheppard, eu teria toda a grana só para mim."
-    hugo ""
+    hugo "If it weren't for you and Sheppard, I'd have all the money to myself."
 
 # game/cenas/dia3/cena34.rpy:15
 translate english CENA34_5d93a7c6:
 
     # hugo "Quem iria desconfiar do pobre Hugo?"
-    hugo ""
+    hugo "Who would ever suspect poor Hugo?"
 
 # game/cenas/dia3/cena34.rpy:19
 translate english CENA34_e955e3c2:
 
     # hugo "Não é mesmo, detetive?"
-    hugo ""
+    hugo "Isn't that right, detective?"
 
 # game/cenas/dia3/cena34.rpy:24
 translate english CENA34_3c7c07d9:
 
     # hugo "Era melhor que nunca tivesse aparecido, sua peste!"
-    hugo ""
+    hugo "It would've been better if you'd never shown up, you pest!"
 
 # game/cenas/dia3/cena34.rpy:26
 translate english CENA34_3bb1c1e8:
 
     # hugo "O senhor pensa que acabou?"
-    hugo ""
+    hugo "You think it's over?"
 
 # game/cenas/dia3/cena34.rpy:27
 translate english CENA34_0064cb35:
 
     # hugo "O senhor acha que está resolvido?"
-    hugo ""
+    hugo "You think it's all settled?"
 
 # game/cenas/dia3/cena34.rpy:28
 translate english CENA34_17ce6197:
 
     # hugo "Ahahahahaha"
-    hugo ""
+    hugo "Ahahahahaha"
 
 # game/cenas/dia3/cena34.rpy:29
 translate english CENA34_8d5bbe50:
 
     # hugo "Engano o seu. Eu irei buscá-lo, detetive..."
-    hugo ""
+    hugo "You're mistaken. I'll come for you, detective..."
 
 # game/cenas/dia3/cena34.rpy:30
 translate english CENA34_a2609e70:
 
     # hugo "Irei sim."
-    hugo ""
+    hugo "Oh, I will."
 
 # game/cenas/dia3/cena34.rpy:31
 translate english CENA34_892314f0:
 
     # vnc "Cale a boca."
-    vnc ""
+    vnc "Shut your mouth."
 
 # game/cenas/dia3/cena34.rpy:32
 translate english CENA34_65b107bc:
 
     # vnc "Teremos muito o que conversar ainda hoje."
-    vnc ""
+    vnc "We'll have much to talk about later today."
 
 # game/cenas/dia3/cena34.rpy:36
 translate english CENA34_a994a799:
 
     # hugo "Aaaaaaaaahhhhhhhh!"
-    hugo ""
+    hugo "Aaaaaaaaahhhhhhhh!"
 
 # game/cenas/dia3/cena34.rpy:41
 translate english CENA34_89b279e0:
 
     # hugo "Me larguem, seus porcos!"
-    hugo ""
+    hugo "Let go of me, you pigs!"
 
 # game/cenas/dia3/cena34.rpy:42
 translate english CENA34_bb8171fa:
 
     # hugo "Vou acabar com vocês."
-    hugo ""
+    hugo "I'll destroy you all."
 
 # game/cenas/dia3/cena34.rpy:43
 translate english CENA34_0b6a8fc4:
 
     # hugo "Acham que conseguem me matar?"
-    hugo ""
+    hugo "You think you can kill me?"
 
 # game/cenas/dia3/cena34.rpy:44
 translate english CENA34_f81da1c4:
 
     # hugo "Pois veremos."
-    hugo ""
+    hugo "We'll see about that."
 
 # game/cenas/dia3/cena34.rpy:45
 translate english CENA34_44eab016:
 
     # hugo "Veremos..."
-    hugo ""
+    hugo "We'll see..."
 
 # game/cenas/dia3/cena34.rpy:46
 translate english CENA34_cdbd0d35:
 
     # hugo "Ahahahahahahaha..."
-    hugo ""
+    hugo "Ahahahahahahaha..."
 
 # game/cenas/dia3/cena34.rpy:53
 translate english CENA34_90b13929:
 
     # hugo "Thorn, não!"
-    hugo ""
+    hugo "Thorn, no!"
 
 # game/cenas/dia3/cena34.rpy:54
 translate english CENA34_597ded15:
 
     # "*Thorn tenta atacar Carlo Venchinni.*"
-    ""
+    "*Thorn tries to attack Carlo Venchinni.*"
 
 # game/cenas/dia3/cena34.rpy:55
 translate english CENA34_6796a8ea:
 
     # vnc "Vira-lata imundo. Matem-no."
-    vnc ""
+    vnc "Filthy mutt. Kill it."
 
 # game/cenas/dia3/cena34.rpy:56
 translate english CENA34_d53c61d1:
 
     # hugo "Thorn! Fuja! Agora!"
-    hugo ""
+    hugo "Thorn! Run! Now!"
 
 # game/cenas/dia3/cena34.rpy:57
 translate english CENA34_83bd9a98:
 
     # hugo "GUNIS ATENDUM KFVOK."
-    hugo ""
+    hugo "GUNIS ATENDUM KFVOK."
 
 # game/cenas/dia3/cena34.rpy:58
 translate english CENA34_5bdc6a2d:
 
     # "*Som de tiro*"
-    ""
+    "*Gunshot sound*"
 
 # game/cenas/dia3/cena34.rpy:59
 translate english CENA34_f5d91f33:
 
     # "*Thorn foge*"
-    ""
+    "*Thorn flees*"
 
 # game/cenas/dia3/cena34.rpy:60
 translate english CENA34_78eaf693:
 
     # vnc "Maldito cão. Fugiu."
-    vnc ""
+    vnc "Damned dog. It got away."
 
 # game/cenas/dia3/cena34.rpy:61
 translate english CENA34_a5498c36:
 
     # "Mas o que foi isso? Parece um código."
-    ""
+    "But what was that? It sounds like a code."
 
 # game/cenas/dia3/cena34.rpy:62
 translate english CENA34_d305a54a:
 
     # "Bom, mas já não importa mais."
-    ""
+    "Well, it doesn't matter anymore."
 
 # game/cenas/dia3/cena34.rpy:67
 translate english CENA34_70643ac1:
 
     # vnc "Levem-no."
-    vnc ""
+    vnc "Take him away."
 
 # game/cenas/dia3/cena34.rpy:68
 translate english CENA34_c454cdb1:
 
     # hugo "Ahahahaha."
-    hugo ""
+    hugo "Ahahahaha."
 
 # game/cenas/dia3/cena34.rpy:73
 translate english CENA34_98b3156a:
 
     # hugo "Isso! Me levem. Me levem."
-    hugo ""
+    hugo "Yes! Take me away. Take me away."
 
 # game/cenas/dia3/cena34.rpy:79
 translate english CENA34_a3adad2b:
 
     # vnc "Assim, me despeço do senhor, detetive Rightclue."
-    vnc ""
+    vnc "And so, I bid you farewell, detective Rightclue."
 
 # game/cenas/dia3/cena34.rpy:80
 translate english CENA34_6d2af4a8:
 
     # drc "Fico grato, senhor Venchinni."
-    drc ""
+    drc "I'm grateful, Mr. Venchinni."
 
 # game/cenas/dia3/cena34.rpy:81
 translate english CENA34_5164a5bb:
 
     # drc "Garantirei sigilo de tudo que ocorreu aqui. Tem minha palavra."
-    drc ""
+    drc "I'll ensure secrecy about everything that happened here. You have my word."
 
 # game/cenas/dia3/cena34.rpy:82
 translate english CENA34_80a4a7a3:
 
     # vnc "Excelente."
-    vnc ""
+    vnc "Excellent."
 
 # game/cenas/dia3/cena34.rpy:83
 translate english CENA34_9729315b:
 
     # vnc "Sheppard confiou em você. Fiz certo ao confiar também."
-    vnc ""
+    vnc "Sheppard trusted you. I was right to trust you as well."
 
 # game/cenas/dia3/cena34.rpy:84
 translate english CENA34_a64e614b:
 
     # drc "Até mais, senhor Venchinni."
-    drc ""
+    drc "Until next time, Mr. Venchinni."
 
 # game/cenas/dia3/cena34.rpy:88
 translate english CENA34_da1fafe1:
 
     # "Acabei me exaltando. Realmente um péssimo hábito..."
-    ""
+    "I ended up losing my temper. Truly a terrible habit..."
 
 # game/cenas/dia3/cena34.rpy:93
 translate english CENA34_9891dc61:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia3/cena34.rpy:98
 translate english CENA34_828555c8:
 
     # cth "..."
-    cth ""
+    cth "..."
 
 # game/cenas/dia3/cena34.rpy:99
 translate english CENA34_7d90aa18:
 
     # drc "Bom, meu trabalho termina aqui."
-    drc ""
+    drc "Well, my work ends here."
 
 # game/cenas/dia3/cena34.rpy:100
 translate english CENA34_b7f19cfb:
 
     # joe "Senhor Rightclue. Eu nem sei o que dizer. Sinto que recebemos o senhor de forma tão áspera."
-    joe ""
+    joe "Mr. Rightclue. I hardly know what to say. I feel we received you so harshly."
 
 # game/cenas/dia3/cena34.rpy:101
 translate english CENA34_88481937:
 
     # joe "Mas se não fosse o senhor, não conseguiríamos nos salvar."
-    joe ""
+    joe "But if it weren't for you, we wouldn't have been able to save ourselves."
 
 # game/cenas/dia3/cena34.rpy:102
 translate english CENA34_2e0f232b:
 
     # cth "O senhor provou ser leal, honrado."
-    cth ""
+    cth "You proved to be loyal, honorable."
 
 # game/cenas/dia3/cena34.rpy:103
 translate english CENA34_35510fcf:
 
     # cth "Permaneceu. Nos salvou."
-    cth ""
+    cth "You stayed. You saved us."
 
 # game/cenas/dia3/cena34.rpy:104
 translate english CENA34_deeaf5c2:
 
     # cth "Me parece até um cara legal agora..."
-    cth ""
+    cth "He even seems like a nice guy now..."
 
 # game/cenas/dia3/cena34.rpy:105
 translate english CENA34_d2b6c3f7:
 
     # "Como diria Sheppard: \"Ela está elogiando... Acredite, ela seria mais áspera...\""
-    ""
+    "As Sheppard would say: \"She's complimenting you... Believe me, she would be much harsher...\""
 
 # game/cenas/dia3/cena34.rpy:106
 translate english CENA34_90855393:
 
     # drc "É meu trabalho. Sinto tanto por vocês, de verdade."
-    drc ""
+    drc "It's my job. I'm so sorry for you all, truly."
 
 # game/cenas/dia3/cena34.rpy:107
 translate english CENA34_34d5e4d6:
 
     # drc "Estou arrasado. Perderam mais duas pessoas no período que estive aqui. Eu realmente sinto muito."
-    drc ""
+    drc "I'm devastated. You lost two more people during the time I was here. I really am so sorry."
 
 # game/cenas/dia3/cena34.rpy:108
 translate english CENA34_511d2cb1:
 
     # cth "A justiça foi feita, senhor. Estamos arrasados. Joe e eu temos apenas um ao outro agora."
-    cth ""
+    cth "Justice has been done, sir. We're devastated. Joe and I have only each other now."
 
 # game/cenas/dia3/cena34.rpy:109
 translate english CENA34_b67915d7:
 
     # cth "Mas saberemos que estamos seguros."
-    cth ""
+    cth "But we'll know that we're safe."
 
 # game/cenas/dia3/cena34.rpy:110
 translate english CENA34_9891dc61_1:
 
     # joe "..."
-    joe ""
+    joe "..."
 
 # game/cenas/dia3/cena34.rpy:111
 translate english CENA34_5099cb12:
 
     # cth "Sairemos daqui. Esse lugar está manchado demais com o sangue de nossa família."
-    cth ""
+    cth "We'll leave this place. It's far too stained with the blood of our family."
 
 # game/cenas/dia3/cena34.rpy:112
 translate english CENA34_1b4505ca:
 
     # joe "Eu irei para outro lugar. Recomeçar. Mas parece que ainda estou em um pesadelo."
-    joe ""
+    joe "I'll go somewhere else. Start over. But it still feels like I'm in a nightmare."
 
 # game/cenas/dia3/cena34.rpy:113
 translate english CENA34_da07bc1b:
 
     # cth "Eu também irei. Esse lugar, essa vida. Acho que está na hora de recomeçar. Em outro lugar."
-    cth ""
+    cth "I'll go too. This place, this life. I think it's time to start over. Somewhere else."
 
 # game/cenas/dia3/cena34.rpy:114
 translate english CENA34_0a130ac8:
 
     # drc "Entendo."
-    drc ""
+    drc "I see."
 
 # game/cenas/dia3/cena34.rpy:115
 translate english CENA34_cca53d00:
 
     # cth "Aquilo, Joe..."
-    cth ""
+    cth "That thing, Joe..."
 
 # game/cenas/dia3/cena34.rpy:116
 translate english CENA34_d53f9152:
 
     # cth "Uma padaria, quem sabe?"
-    cth ""
+    cth "A bakery, perhaps?"
 
 # game/cenas/dia3/cena34.rpy:117
 translate english CENA34_67e33c48:
 
     # drc "Uma padaria?"
-    drc ""
+    drc "A bakery?"
 
 # game/cenas/dia3/cena34.rpy:118
 translate english CENA34_048ce9d3:
 
     # "Acho que dei uma breve sorriso..."
-    ""
+    "I think I gave a brief smile..."
 
 # game/cenas/dia3/cena34.rpy:119
 translate english CENA34_82187652:
 
     # drc "Não parece muito sua cara."
-    drc ""
+    drc "That doesn't seem much like you."
 
 # game/cenas/dia3/cena34.rpy:120
 translate english CENA34_458c19e5:
 
     # cth "Meu bem, você realmente não me conhece."
-    cth ""
+    cth "My dear, you really don't know me."
 
 # game/cenas/dia3/cena34.rpy:121
 translate english CENA34_83842d72:
 
     # joe "Hahaha"
-    joe ""
+    joe "Hahaha"
 
 # game/cenas/dia3/cena34.rpy:122
 translate english CENA34_70416326:
 
     # "Um riso. Depois de tanto sofrimento..."
-    ""
+    "A laugh. After so much suffering..."
 
 # game/cenas/dia3/cena34.rpy:123
 translate english CENA34_14488f30:
 
     # "Eles estão tentando superar tudo isso. Será difícil, mas tenho certeza que juntos conseguirão."
-    ""
+    "They're trying to get past all of this. It will be hard, but I'm sure that together they'll make it."
 
 # game/cenas/dia3/cena34.rpy:124
 translate english CENA34_d283a83e:
 
     # drc "Bom. Desejo toda a sorte do mundo aos dois."
-    drc ""
+    drc "Good. I wish the two of them all the luck in the world."
 
 # game/cenas/dia3/cena34.rpy:125
 translate english CENA34_09bd6de3:
 
     # joe "Muito obrigado ao senhor."
-    joe ""
+    joe "Thank you so much, sir."
 
 # game/cenas/dia3/cena34.rpy:126
 translate english CENA34_9a5abe2d:
 
     # cth "Obrigada."
-    cth ""
+    cth "Thank you."
 
 # game/cenas/dia3/cena34.rpy:127
 translate english CENA34_9d925f37:
 
     # drc "É meu trabalho."
-    drc ""
+    drc "It's my job."
 
 # game/cenas/dia3/cena34.rpy:128
 translate english CENA34_c1e268e6:
 
     # drc "Bom, me despeço por aqui."
-    drc ""
+    drc "Well, I'll take my leave here."
 
 # game/cenas/dia3/cena34.rpy:129
 translate english CENA34_e3e17b78:
 
     # drc "Até mais a vocês."
-    drc ""
+    drc "Until next time, to you both."
 
 # game/cenas/dia3/cena34.rpy:130
 translate english CENA34_0ac05f84:
 
     # cth "Apareça na padaria algum dia."
-    cth ""
+    cth "Drop by the bakery someday."
 
 # game/cenas/dia3/cena34.rpy:131
 translate english CENA34_ec72bb01:
 
     # cth "Quem sabe cobro menos que o dobro de você."
-    cth ""
+    cth "Maybe I'll charge you less than double."
 
 # game/cenas/dia3/cena34.rpy:132
 translate english CENA34_d79dadac:
 
     # joe "Será sempre um prazer, senhor Rightclue."
-    joe ""
+    joe "It will always be a pleasure, Mr. Rightclue."
 
 # game/cenas/dia3/cena34.rpy:133
 translate english CENA34_5ca1fc75:
 
     # drc "Então nos veremos novamente."
-    drc ""
+    drc "Then we'll see each other again."
 
 # game/cenas/dia3/cena34.rpy:134
 translate english CENA34_36abef76:
 
     # drc "Não é um adeus. É algo mais como um até logo."
-    drc ""
+    drc "It's not a goodbye. It's more like a see-you-soon."
 
 # game/cenas/dia3/cena34.rpy:135
 translate english CENA34_b9e334e4:
 
     # "Não consegui controlar o sorriso."
-    ""
+    "I couldn't hold back the smile."
 
 # game/cenas/dia3/cena34.rpy:136
 translate english CENA34_7935d12d:
 
     # joe "Até mais, senhor Rightclue."
-    joe ""
+    joe "Until next time, Mr. Rightclue."
 
 # game/cenas/dia3/cena34.rpy:137
 translate english CENA34_88e6aa4a:
 
     # cth "Até mais, detetive, e obrigada."
-    cth ""
+    cth "Until next time, detective, and thank you."
 
 # game/cenas/dia3/cena34.rpy:138
 translate english CENA34_adf7a82c:
 
     # drc "Até."
-    drc ""
+    drc "See you."
 
 # game/cenas/dia3/cena34.rpy:145
 translate english CENA34_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena34.rpy:146
 translate english CENA34_022f71df:
 
     # "Vejo fotos do senhor Sheppard e de Kamira na perede."
-    ""
+    "I see photos of Mr. Sheppard and Kamira on the wall."
 
 # game/cenas/dia3/cena34.rpy:147
 translate english CENA34_4bb0c7b9:
 
     # "Realmente, odeio despedidas."
-    ""
+    "Truly, I hate goodbyes."
 
 # game/cenas/dia3/cena34.rpy:148
 translate english CENA34_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/cenas/dia3/cena34.rpy:149
 translate english CENA34_23508c25:
 
     # "Mas a justiça foi feita. Espero que estejam vendo isso de algum lugar."
-    ""
+    "But justice has been done. I hope you're watching this from somewhere."
 

--- a/game/tl/english/cenas/dia3/cena35.rpy
+++ b/game/tl/english/cenas/dia3/cena35.rpy
@@ -4,23 +4,23 @@
 translate english CENA35_c2c22c61:
 
     # "Cheguei ao fim de mais um caso."
-    ""
+    "I've reached the end of another case."
 
 # game/cenas/dia3/cena35.rpy:7
 translate english CENA35_8e608d31:
 
     # "Deveras triste, confesso."
-    ""
+    "Quite sad, I confess."
 
 # game/cenas/dia3/cena35.rpy:8
 translate english CENA35_2486b7ff:
 
     # "Mas acho que ficará na história."
-    ""
+    "But I think it will go down in history."
 
 # game/cenas/dia3/cena35.rpy:9
 translate english CENA35_4c9b959e:
 
     # "Pelo menos na minha história..."
-    ""
+    "At least in my history..."
 

--- a/game/tl/english/puzzles/dia2/app_dia02.rpy
+++ b/game/tl/english/puzzles/dia2/app_dia02.rpy
@@ -4,11 +4,11 @@
 translate english APP_DIA2_GAME_OVER_54ceb729:
 
     # "Não era isso..."
-    ""
+    "That wasn't it..."
 
 # game/puzzles/dia2/app_dia02.rpy:37
 translate english APP_DIA2_GAME_OVER_f2e92058:
 
     # "Vou tentar novamente!"
-    ""
+    "I'll try again!"
 

--- a/game/tl/english/puzzles/dia2/ide_dia02.rpy
+++ b/game/tl/english/puzzles/dia2/ide_dia02.rpy
@@ -4,137 +4,137 @@
 translate english IDE_02_ESCOLHE_FRASE_c60490e4:
 
     # "Onde coloquei aquele bilhete?"
-    ""
+    "Where did I put that note?"
 
 # game/puzzles/dia2/ide_dia02.rpy:47
 translate english IDE_02_ESCOLHE_FRASE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02.rpy:55
 translate english IDE_02_ESCOLHE_FRASE_a03eedd8:
 
     # "Está todo rasgado."
-    ""
+    "It's all torn up."
 
 # game/puzzles/dia2/ide_dia02.rpy:71
 translate english IDE_02_ESCOLHEU_PAPEL_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02.rpy:72
 translate english IDE_02_ESCOLHEU_PAPEL_8afddc82:
 
     # "Aqui está."
-    ""
+    "Here it is."
 
 # game/puzzles/dia2/ide_dia02.rpy:78
 translate english IDE_02_ESCOLHEU_PAPEL_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:83
 translate english IDE_02_ESCOLHEU_PAPEL_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:98
 translate english IDE_02_ESCOLHEU_LENCO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02.rpy:104
 translate english IDE_02_ESCOLHEU_LENCO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:108
 translate english IDE_02_ESCOLHEU_LENCO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:127
 translate english IDE_02_ESCOLHEU_OUTRO_6357a383:
 
     # "Não sei, acho que não é isto..."
-    ""
+    "I don't know, I don't think this is it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:133
 translate english IDE_02_ESCOLHEU_OUTRO_6357a383_1:
 
     # "Não sei, acho que não é isto..."
-    ""
+    "I don't know, I don't think this is it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:137
 translate english IDE_02_ESCOLHEU_OUTRO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:153
 translate english IDE_02_ESCOLHEU_LAPIS_d72b5b0f:
 
     # "É isso."
-    ""
+    "That's it."
 
 # game/puzzles/dia2/ide_dia02.rpy:154
 translate english IDE_02_ESCOLHEU_LAPIS_039544f3:
 
     # "O lápis é pontudo e pequeno o suficiente."
-    ""
+    "The pencil is pointed and small enough."
 
 # game/puzzles/dia2/ide_dia02.rpy:160
 translate english IDE_02_ESCOLHEU_LAPIS_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:165
 translate english IDE_02_ESCOLHEU_LAPIS_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:180
 translate english IDE_02_ESCOLHEU_LIVROS_5eccfe09:
 
     # "Livros... isso aí!"
-    ""
+    "Books... that's it!"
 
 # game/puzzles/dia2/ide_dia02.rpy:186
 translate english IDE_02_ESCOLHEU_LIVROS_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:191
 translate english IDE_02_ESCOLHEU_LIVROS_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:206
 translate english IDE_02_ESCOLHEU_CAMERA_6f3e6eef:
 
     # "Câmera... isso aí!"
-    ""
+    "Camera... that's it!"
 
 # game/puzzles/dia2/ide_dia02.rpy:212
 translate english IDE_02_ESCOLHEU_CAMERA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02.rpy:217
 translate english IDE_02_ESCOLHEU_CAMERA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 

--- a/game/tl/english/puzzles/dia2/ide_dia02_2.rpy
+++ b/game/tl/english/puzzles/dia2/ide_dia02_2.rpy
@@ -4,173 +4,173 @@
 translate english IDE_02_2_ESCOLHE_FRASE_8cb636d5:
 
     # "A Kamira deixou uma pista."
-    ""
+    "Kamira left a clue."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:48
 translate english IDE_02_2_ESCOLHE_FRASE_fef09f7f:
 
     # "O que eu estava procurando era..."
-    ""
+    "What I was looking for was..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:53
 translate english IDE_02_2_ESCOLHE_FRASE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:54
 translate english IDE_02_2_ESCOLHE_FRASE_f252c19e:
 
     # "Esse dispositivo tem uma trava de segurança. O aparelho só reproduz com a tampa fechada."
-    ""
+    "This device has a safety lock. It only plays with the lid closed."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:55
 translate english IDE_02_2_ESCOLHE_FRASE_ed03c249:
 
     # "Preciso arranjar uma forma de fechar a tampa do gravador."
-    ""
+    "I need to find a way to close the recorder's lid."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:56
 translate english IDE_02_2_ESCOLHE_FRASE_c5a370df:
 
     # "Há um pequeno pino na tampa. E uma peça oca com um mola ao fundo no corpo do gravador. Não consigo ver muito bem lá dentro."
-    ""
+    "There's a small pin on the lid. And a hollow piece with a spring at the back inside the recorder's body. I can't see very well in there."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:57
 translate english IDE_02_2_ESCOLHE_FRASE_6b1c3bde:
 
     # "Para que essa trava encaixe, preciso deixar a peça oca alinhada em algum lugar da primeira linha."
-    ""
+    "For this latch to fit, I need to line up the hollow piece somewhere in the first row."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:58
 translate english IDE_02_2_ESCOLHE_FRASE_832d9dea:
 
     # "Preciso de algo pontudo, mas pequeno o suficiente para conseguir manipulá-lo."
-    ""
+    "I need something pointed, but small enough to handle it."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:66
 translate english IDE_02_2_ESCOLHE_FRASE_b2230658:
 
     # "Com o lápis, eu vou conseguir."
-    ""
+    "With the pencil, I'll manage it."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:82
 translate english IDE_02_2_ESCOLHEU_GRAVADOR_cff7fda6:
 
     # "Está aqui... Um gravador."
-    ""
+    "It's here... A recorder."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:83
 translate english IDE_02_2_ESCOLHEU_GRAVADOR_013dc8a1:
 
     # "Parece equipamento de ponta."
-    ""
+    "Looks like top-of-the-line equipment."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:89
 translate english IDE_02_2_ESCOLHEU_GRAVADOR_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:94
 translate english IDE_02_2_ESCOLHEU_GRAVADOR_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:108
 translate english IDE_02_2_ESCOLHEU_TESOURA_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:114
 translate english IDE_02_2_ESCOLHEU_TESOURA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:118
 translate english IDE_02_2_ESCOLHEU_TESOURA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:133
 translate english IDE_02_2_ESCOLHEU_LAPIS_d72b5b0f:
 
     # "É isso."
-    ""
+    "That's it."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:134
 translate english IDE_02_2_ESCOLHEU_LAPIS_039544f3:
 
     # "O lápis é pontudo e pequeno o suficiente."
-    ""
+    "The pencil is pointed and small enough."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:140
 translate english IDE_02_2_ESCOLHEU_LAPIS_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:145
 translate english IDE_02_2_ESCOLHEU_LAPIS_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:160
 translate english IDE_02_2_ESCOLHEU_LIVROS_5eccfe09:
 
     # "Livros... isso aí!"
-    ""
+    "Books... that's it!"
 
 # game/puzzles/dia2/ide_dia02_2.rpy:166
 translate english IDE_02_2_ESCOLHEU_LIVROS_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:171
 translate english IDE_02_2_ESCOLHEU_LIVROS_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:186
 translate english IDE_02_2_ESCOLHEU_CAMERA_6f3e6eef:
 
     # "Câmera... isso aí!"
-    ""
+    "Camera... that's it!"
 
 # game/puzzles/dia2/ide_dia02_2.rpy:192
 translate english IDE_02_2_ESCOLHEU_CAMERA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:197
 translate english IDE_02_2_ESCOLHEU_CAMERA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:211
 translate english IDE_02_2_ESCOLHEU_LENCO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:217
 translate english IDE_02_2_ESCOLHEU_LENCO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia2/ide_dia02_2.rpy:221
 translate english IDE_02_2_ESCOLHEU_LENCO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 

--- a/game/tl/english/puzzles/dia2/lop_4x4_dia02.rpy
+++ b/game/tl/english/puzzles/dia2/lop_4x4_dia02.rpy
@@ -4,29 +4,29 @@
 translate english LIGHTS_OUT_PUZZLE_4X4_DIA02_a396bf19:
 
     # "Aparentemente, há 16 peças luminosas."
-    ""
+    "Apparently, there are 16 glowing pieces."
 
 # game/puzzles/dia2/lop_4x4_dia02.rpy:37
 translate english LIGHTS_OUT_PUZZLE_4X4_DIA02_68c944bf:
 
     # "Ao clicá-las, posso ativar ou desativar."
-    ""
+    "By clicking them, I can turn them on or off."
 
 # game/puzzles/dia2/lop_4x4_dia02.rpy:38
 translate english LIGHTS_OUT_PUZZLE_4X4_DIA02_8ececad6:
 
     # "E isso influencia nas peças em volta."
-    ""
+    "And that affects the surrounding pieces."
 
 # game/puzzles/dia2/lop_4x4_dia02.rpy:39
 translate english LIGHTS_OUT_PUZZLE_4X4_DIA02_1d0c5d35:
 
     # "Preciso deixar todas ligadas."
-    ""
+    "I need to get them all lit."
 
 # game/puzzles/dia2/lop_4x4_dia02.rpy:50
 translate english FIM_LOP_4X4_DIA02_61ea5bb9:
 
     # "Droga, vou tentar novamente..."
-    ""
+    "Darn, I'll try again..."
 

--- a/game/tl/english/puzzles/dia2/pac_dia02.rpy
+++ b/game/tl/english/puzzles/dia2/pac_dia02.rpy
@@ -4,89 +4,89 @@
 translate english PAC2_SELECIONA_GAVETA_e15ec279:
 
     # "Espera, deve ter algo a mais atrás da cômoda."
-    ""
+    "Wait, there must be something more behind the dresser."
 
 # game/puzzles/dia2/pac_dia02.rpy:138
 translate english PAC2_SELECIONA_GAVETA_0059031d:
 
     # "Talvez se eu empurrar..."
-    ""
+    "Maybe if I push..."
 
 # game/puzzles/dia2/pac_dia02.rpy:139
 translate english PAC2_SELECIONA_GAVETA_de1e1cac:
 
     # "Isso, tem duas gavetas escondidas!"
-    ""
+    "There, there are two hidden drawers!"
 
 # game/puzzles/dia2/pac_dia02.rpy:140
 translate english PAC2_SELECIONA_GAVETA_0998797e:
 
     # "Vamos ver o que há dentro delas..."
-    ""
+    "Let's see what's inside them..."
 
 # game/puzzles/dia2/pac_dia02.rpy:143
 translate english PAC2_SELECIONA_GAVETA_264ed9a5:
 
     # "Um gravador. Está com a tampa aberta."
-    ""
+    "A recorder. Its lid is open."
 
 # game/puzzles/dia2/pac_dia02.rpy:152
 translate english PAC2_SELECIONA_GAVETA_8136387c:
 
     # "Também tem mais uma coisa..."
-    ""
+    "There's one more thing too..."
 
 # game/puzzles/dia2/pac_dia02.rpy:155
 translate english PAC2_SELECIONA_GAVETA_17eee767:
 
     # "Uma tesoura. Vou levar, talvez me seja útil..."
-    ""
+    "A pair of scissors. I'll take them, they might be useful..."
 
 # game/puzzles/dia2/pac_dia02.rpy:164
 translate english PAC2_SELECIONA_GAVETA_246cbe55:
 
     # "Acho que já coletei todas as pistas que eu precisava..."
-    ""
+    "I think I've collected all the clues I needed..."
 
 # game/puzzles/dia2/pac_dia02.rpy:165
 translate english PAC2_SELECIONA_GAVETA_7e8ab5fd:
 
     # drc "Acho que isto é suficiente, She..."
-    drc ""
+    drc "I think this is enough, She..."
 
 # game/puzzles/dia2/pac_dia02.rpy:166
 translate english PAC2_SELECIONA_GAVETA_6d84fb3b:
 
     # "É verdade..."
-    ""
+    "It's true..."
 
 # game/puzzles/dia2/pac_dia02.rpy:167
 translate english PAC2_SELECIONA_GAVETA_39483c54:
 
     # "Ele não está mais aqui..."
-    ""
+    "He's not here anymore..."
 
 # game/puzzles/dia2/pac_dia02.rpy:168
 translate english PAC2_SELECIONA_GAVETA_d172e432:
 
     # "Mas tudo bem. Vou fazer isso por ele. Pela Kamira também!"
-    ""
+    "But it's all right. I'll do this for him. For Kamira too!"
 
 # game/puzzles/dia2/pac_dia02.rpy:169
 translate english PAC2_SELECIONA_GAVETA_280825a8:
 
     # "Vou descobrir quem está por trás desses assassinatos!"
-    ""
+    "I'm going to find out who's behind these murders!"
 
 # game/puzzles/dia2/pac_dia02.rpy:170
 translate english PAC2_SELECIONA_GAVETA_5e00812e:
 
     # "Só para garantir, acho que vou dar uma última olhada."
-    ""
+    "Just to be sure, I think I'll take one last look."
 
 # game/puzzles/dia2/pac_dia02.rpy:173
 translate english PAC2_SELECIONA_GAVETA_14c355be:
 
     # "Já retirei tudo que estava escondido da cômoda. Não preciso mais olhá-la."
-    ""
+    "I've already taken everything hidden from the dresser. I don't need to look at it anymore."
 

--- a/game/tl/english/puzzles/dia2/slp_dia02.rpy
+++ b/game/tl/english/puzzles/dia2/slp_dia02.rpy
@@ -4,41 +4,41 @@
 translate english SLIDER_PUZZLE_3X3_DIA02_84c6acb1:
 
     # "O bilhete está partido em pedaços."
-    ""
+    "The note is broken into pieces."
 
 # game/puzzles/dia2/slp_dia02.rpy:64
 translate english SLIDER_PUZZLE_3X3_DIA02_96814bc5:
 
     # "Ao clicar em uma peça, posso deslizá-la para um espaço vazio."
-    ""
+    "By clicking a piece, I can slide it into an empty space."
 
 # game/puzzles/dia2/slp_dia02.rpy:65
 translate english SLIDER_PUZZLE_3X3_DIA02_956a258c:
 
     # "Preciso deixar todos os pedaços na ordem correta."
-    ""
+    "I need to get all the pieces in the right order."
 
 # game/puzzles/dia2/slp_dia02.rpy:74
 translate english SLP_GAME_OVER_3X3_DIA02_61ea5bb9:
 
     # "Droga, vou tentar novamente..."
-    ""
+    "Darn, I'll try again..."
 
 # game/puzzles/dia2/slp_dia02.rpy:75
 translate english SLP_GAME_OVER_3X3_DIA02_2bba9f4a:
 
     # "Talvez seja melhor eu identificar, primeiro, as palavras."
-    ""
+    "Maybe it's better to identify the words first."
 
 # game/puzzles/dia2/slp_dia02.rpy:76
 translate english SLP_GAME_OVER_3X3_DIA02_11a758a2:
 
     # "E, depois, tentar descobrir onde cada uma está posicionada no bilhete."
-    ""
+    "And then, try to figure out where each one is positioned in the note."
 
 # game/puzzles/dia2/slp_dia02.rpy:77
 translate english SLP_GAME_OVER_3X3_DIA02_c6641514:
 
     # "Posso me atentar aos entornos de cada peça."
-    ""
+    "I can pay attention to the surroundings of each piece."
 

--- a/game/tl/english/puzzles/dia2/slp_dia02_2.rpy
+++ b/game/tl/english/puzzles/dia2/slp_dia02_2.rpy
@@ -4,53 +4,53 @@
 translate english SLIDER_PUZZLE_3X3_DIA02_2_56d106c9:
 
     # "Posso usar o lápis para manipular as peças."
-    ""
+    "I can use the pencil to handle the pieces."
 
 # game/puzzles/dia2/slp_dia02_2.rpy:62
 translate english SLIDER_PUZZLE_3X3_DIA02_2_6eddacf7:
 
     # "Ao clicar numa peça, posso deslizá-la para o espaço vazio."
-    ""
+    "By clicking a piece, I can slide it into the empty space."
 
 # game/puzzles/dia2/slp_dia02_2.rpy:63
 translate english SLIDER_PUZZLE_3X3_DIA02_2_5318cefd:
 
     # "Tenho que deixar a mola na posição correta."
-    ""
+    "I have to get the spring into the right position."
 
 # game/puzzles/dia2/slp_dia02_2.rpy:64
 translate english SLIDER_PUZZLE_3X3_DIA02_2_ed9a9f42:
 
     # "Deve ficar na primeira linha, mas em qual posição?"
-    ""
+    "It should be in the first row, but in which position?"
 
 # game/puzzles/dia2/slp_dia02_2.rpy:73
 translate english SLP_GAME_OVER_3X3_DIA02_2_61ea5bb9:
 
     # "Droga, vou tentar novamente..."
-    ""
+    "Darn, I'll try again..."
 
 # game/puzzles/dia2/slp_dia02_2.rpy:74
 translate english SLP_GAME_OVER_3X3_DIA02_2_5a0f94cb:
 
     # "As setas parecem indicar para onde, a peça em qual está desenhada, deve ficar..."
-    ""
+    "The arrows seem to indicate where the piece they're drawn on should go..."
 
 # game/puzzles/dia2/slp_dia02_2.rpy:75
 translate english SLP_GAME_OVER_3X3_DIA02_2_562774d3:
 
     # "Talvez apontar para as bordas?"
-    ""
+    "Maybe they point to the edges?"
 
 # game/puzzles/dia2/slp_dia02_2.rpy:76
 translate english SLP_GAME_OVER_3X3_DIA02_2_bbd45236:
 
     # "Onde a peça com o círculo fica então...?"
-    ""
+    "Where does the piece with the circle go, then...?"
 
 # game/puzzles/dia2/slp_dia02_2.rpy:77
 translate english SLP_GAME_OVER_3X3_DIA02_2_d2ce6fb7:
 
     # "Talvez... no meio?"
-    ""
+    "Maybe... in the middle?"
 

--- a/game/tl/english/puzzles/dia3/app_dia03.rpy
+++ b/game/tl/english/puzzles/dia3/app_dia03.rpy
@@ -4,11 +4,11 @@
 translate english APP_DIA3_GAME_OVER_54ceb729:
 
     # "Não era isso..."
-    ""
+    "That wasn't it..."
 
 # game/puzzles/dia3/app_dia03.rpy:37
 translate english APP_DIA3_GAME_OVER_f2e92058:
 
     # "Vou tentar novamente!"
-    ""
+    "I'll try again!"
 

--- a/game/tl/english/puzzles/dia3/ide_dia03.rpy
+++ b/game/tl/english/puzzles/dia3/ide_dia03.rpy
@@ -4,185 +4,185 @@
 translate english IDE_03_ESCOLHE_FRASE_df355c50:
 
     # "Onde o Joe pode estar escondendo algo?"
-    ""
+    "Where could Joe be hiding something?"
 
 # game/puzzles/dia3/ide_dia03.rpy:49
 translate english IDE_03_ESCOLHE_FRASE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:50
 translate english IDE_03_ESCOLHE_FRASE_db57ecb3:
 
     # "Mas tem um problema."
-    ""
+    "But there's a problem."
 
 # game/puzzles/dia3/ide_dia03.rpy:51
 translate english IDE_03_ESCOLHE_FRASE_fba2a808:
 
     # "Aparentemente, o cofre tem uma fechadura."
-    ""
+    "Apparently, the safe has a lock."
 
 # game/puzzles/dia3/ide_dia03.rpy:52
 translate english IDE_03_ESCOLHE_FRASE_198c30b5:
 
     # "O que eu posso usar para abri-lo?"
-    ""
+    "What can I use to open it?"
 
 # game/puzzles/dia3/ide_dia03.rpy:75
 translate english IDE_03_ESCOLHEU_LENCO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:81
 translate english IDE_03_ESCOLHEU_LENCO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:86
 translate english IDE_03_ESCOLHEU_LENCO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:100
 translate english IDE_03_ESCOLHEU_LENCO_PELOS_5efeb44b:
 
     # "Lenço com pelos. Não são de um ser humano."
-    ""
+    "A handkerchief with hairs. They're not from a human."
 
 # game/puzzles/dia3/ide_dia03.rpy:106
 translate english IDE_03_ESCOLHEU_LENCO_PELOS_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:111
 translate english IDE_03_ESCOLHEU_LENCO_PELOS_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:125
 translate english IDE_03_ESCOLHEU_CHAVE_5fceed6e:
 
     # "É isso!"
-    ""
+    "That's it!"
 
 # game/puzzles/dia3/ide_dia03.rpy:126
 translate english IDE_03_ESCOLHEU_CHAVE_83b5880a:
 
     # "Essa é a chave do cofre!"
-    ""
+    "This is the key to the safe!"
 
 # game/puzzles/dia3/ide_dia03.rpy:132
 translate english IDE_03_ESCOLHEU_CHAVE_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:137
 translate english IDE_03_ESCOLHEU_CHAVE_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:152
 translate english IDE_03_ESCOLHEU_COFRE_5fceed6e:
 
     # "É isso!"
-    ""
+    "That's it!"
 
 # game/puzzles/dia3/ide_dia03.rpy:153
 translate english IDE_03_ESCOLHEU_COFRE_d9a9ae94:
 
     # "O cofre deve estar escondendo algo..."
-    ""
+    "The safe must be hiding something..."
 
 # game/puzzles/dia3/ide_dia03.rpy:159
 translate english IDE_03_ESCOLHEU_COFRE_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:164
 translate english IDE_03_ESCOLHEU_COFRE_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:178
 translate english IDE_03_ESCOLHEU_TELEFONE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:184
 translate english IDE_03_ESCOLHEU_TELEFONE_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:189
 translate english IDE_03_ESCOLHEU_TELEFONE_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:203
 translate english IDE_03_ESCOLHEU_VITROLA_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:209
 translate english IDE_03_ESCOLHEU_VITROLA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:214
 translate english IDE_03_ESCOLHEU_VITROLA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:228
 translate english IDE_03_ESCOLHEU_VELA_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:234
 translate english IDE_03_ESCOLHEU_VELA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:239
 translate english IDE_03_ESCOLHEU_VELA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:253
 translate english IDE_03_ESCOLHEU_RADIO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03.rpy:259
 translate english IDE_03_ESCOLHEU_RADIO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03.rpy:264
 translate english IDE_03_ESCOLHEU_RADIO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 

--- a/game/tl/english/puzzles/dia3/ide_dia03_2.rpy
+++ b/game/tl/english/puzzles/dia3/ide_dia03_2.rpy
@@ -4,89 +4,89 @@
 translate english IDE_03_2_ESCOLHEU_LENCO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:71
 translate english IDE_03_2_ESCOLHEU_LENCO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:76
 translate english IDE_03_2_ESCOLHEU_LENCO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:90
 translate english IDE_03_2_ESCOLHEU_TELEFONE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:96
 translate english IDE_03_2_ESCOLHEU_TELEFONE_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:101
 translate english IDE_03_2_ESCOLHEU_TELEFONE_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:115
 translate english IDE_03_2_ESCOLHEU_VITROLA_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:121
 translate english IDE_03_2_ESCOLHEU_VITROLA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:126
 translate english IDE_03_2_ESCOLHEU_VITROLA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:140
 translate english IDE_03_2_ESCOLHEU_VELA_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:146
 translate english IDE_03_2_ESCOLHEU_VELA_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:151
 translate english IDE_03_2_ESCOLHEU_VELA_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:165
 translate english IDE_03_2_ESCOLHEU_RADIO_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:171
 translate english IDE_03_2_ESCOLHEU_RADIO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/dia3/ide_dia03_2.rpy:176
 translate english IDE_03_2_ESCOLHEU_RADIO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 

--- a/game/tl/english/puzzles/dia3/pac_dia03.rpy
+++ b/game/tl/english/puzzles/dia3/pac_dia03.rpy
@@ -4,191 +4,191 @@
 translate english PAC3_SELECIONA_ABAJUR_3ac13fbf:
 
     # "Parece ter algo dentro do abajur..."
-    ""
+    "There seems to be something inside the lamp..."
 
 # game/puzzles/dia3/pac_dia03.rpy:153
 translate english PAC3_SELECIONA_ABAJUR_caf93fa5:
 
     # "Uma chave..."
-    ""
+    "A key..."
 
 # game/puzzles/dia3/pac_dia03.rpy:154
 translate english PAC3_SELECIONA_ABAJUR_9f45c33e:
 
     # "Estava muito bem escondida."
-    ""
+    "It was very well hidden."
 
 # game/puzzles/dia3/pac_dia03.rpy:155
 translate english PAC3_SELECIONA_ABAJUR_e2b37e06:
 
     # "Mas por quê?"
-    ""
+    "But why?"
 
 # game/puzzles/dia3/pac_dia03.rpy:165
 translate english PAC3_SELECIONA_ABAJUR_246cbe55:
 
     # "Acho que já coletei todas as pistas que eu precisava..."
-    ""
+    "I think I've collected all the clues I needed..."
 
 # game/puzzles/dia3/pac_dia03.rpy:166
 translate english PAC3_SELECIONA_ABAJUR_856b2de1:
 
     # "Vamos lá, estou quase acabando com isso!"
-    ""
+    "Come on, I'm almost done with this!"
 
 # game/puzzles/dia3/pac_dia03.rpy:169
 translate english PAC3_SELECIONA_ABAJUR_b87805b7:
 
     # "Não há mais nada escondido no abajur."
-    ""
+    "There's nothing else hidden in the lamp."
 
 # game/puzzles/dia3/pac_dia03.rpy:176
 translate english PAC3_SELECIONA_COFRE_6329724f:
 
     # "Interessante..."
-    ""
+    "Interesting..."
 
 # game/puzzles/dia3/pac_dia03.rpy:177
 translate english PAC3_SELECIONA_COFRE_bdc9a30e:
 
     # "Então, o Joe tem um cofre..."
-    ""
+    "So, Joe has a safe..."
 
 # game/puzzles/dia3/pac_dia03.rpy:178
 translate english PAC3_SELECIONA_COFRE_e950c380:
 
     # "O que será que ele guarda nele?"
-    ""
+    "I wonder what he keeps in it?"
 
 # game/puzzles/dia3/pac_dia03.rpy:188
 translate english PAC3_SELECIONA_COFRE_246cbe55:
 
     # "Acho que já coletei todas as pistas que eu precisava..."
-    ""
+    "I think I've collected all the clues I needed..."
 
 # game/puzzles/dia3/pac_dia03.rpy:189
 translate english PAC3_SELECIONA_COFRE_856b2de1:
 
     # "Vamos lá, estou quase acabando com isso!"
-    ""
+    "Come on, I'm almost done with this!"
 
 # game/puzzles/dia3/pac_dia03.rpy:192
 translate english PAC3_SELECIONA_COFRE_d81e95b2:
 
     # "Já vi o cofre. O que será que o Joe guarda nele?"
-    ""
+    "I've already seen the safe. I wonder what Joe keeps in it?"
 
 # game/puzzles/dia3/pac_dia03.rpy:199
 translate english PAC3_SELECIONA_GAVETA_f33f57d0:
 
     # "Um rádio."
-    ""
+    "A radio."
 
 # game/puzzles/dia3/pac_dia03.rpy:200
 translate english PAC3_SELECIONA_GAVETA_42f0f66b:
 
     # "Estava guardado na gaveta."
-    ""
+    "It was kept in the drawer."
 
 # game/puzzles/dia3/pac_dia03.rpy:201
 translate english PAC3_SELECIONA_GAVETA_b88d95ab:
 
     # "Talvez não esteja mais funcionando..."
-    ""
+    "Maybe it doesn't work anymore..."
 
 # game/puzzles/dia3/pac_dia03.rpy:210
 translate english PAC3_SELECIONA_GAVETA_bae5653e:
 
     # "Já vi as gavetas. Não há mais nada nelas."
-    ""
+    "I've already seen the drawers. There's nothing else in them."
 
 # game/puzzles/dia3/pac_dia03.rpy:217
 translate english PAC3_SELECIONA_TELEFONE_9936dbc8:
 
     # "Um telefone..."
-    ""
+    "A telephone..."
 
 # game/puzzles/dia3/pac_dia03.rpy:218
 translate english PAC3_SELECIONA_TELEFONE_c4c2d8cd:
 
     # "Está num lugar um pouco... estranho..."
-    ""
+    "It's in a slightly... strange place..."
 
 # game/puzzles/dia3/pac_dia03.rpy:219
 translate english PAC3_SELECIONA_TELEFONE_b09cca17:
 
     # "O Joe parece ser um rapaz meio desorganizado..."
-    ""
+    "Joe seems to be a rather disorganized young man..."
 
 # game/puzzles/dia3/pac_dia03.rpy:220
 translate english PAC3_SELECIONA_TELEFONE_92f0b07c:
 
     # "Ou gosta muito de falar no telefone sentado."
-    ""
+    "Or he really likes talking on the phone while sitting down."
 
 # game/puzzles/dia3/pac_dia03.rpy:221
 translate english PAC3_SELECIONA_TELEFONE_b9fc93fb:
 
     # "Mas, enfim, de volta à investigação..."
-    ""
+    "But anyway, back to the investigation..."
 
 # game/puzzles/dia3/pac_dia03.rpy:230
 translate english PAC3_SELECIONA_TELEFONE_c3d97122:
 
     # "Não preciso mais ver o telefone..."
-    ""
+    "I don't need to look at the phone anymore..."
 
 # game/puzzles/dia3/pac_dia03.rpy:237
 translate english PAC3_SELECIONA_VITROLA_09e0de82:
 
     # "Uma vitrola."
-    ""
+    "A record player."
 
 # game/puzzles/dia3/pac_dia03.rpy:238
 translate english PAC3_SELECIONA_VITROLA_a6faffc6:
 
     # "Parece que o Joe gosta de escutar uma boa música na tranquilidade de seu quarto."
-    ""
+    "It seems Joe likes to listen to good music in the quiet of his room."
 
 # game/puzzles/dia3/pac_dia03.rpy:247
 translate english PAC3_SELECIONA_VITROLA_ab604b8e:
 
     # "Não preciso mais ver a vitrola..."
-    ""
+    "I don't need to look at the record player anymore..."
 
 # game/puzzles/dia3/pac_dia03.rpy:254
 translate english PAC3_SELECIONA_VELA_7d032746:
 
     # "Uma vela."
-    ""
+    "A candle."
 
 # game/puzzles/dia3/pac_dia03.rpy:255
 translate english PAC3_SELECIONA_VELA_0ca0c941:
 
     # "Está pendurada na parede do quarto."
-    ""
+    "It's hanging on the bedroom wall."
 
 # game/puzzles/dia3/pac_dia03.rpy:256
 translate english PAC3_SELECIONA_VELA_b7a2b107:
 
     # "Mas o que me incomoda é que está muito perto da cama..."
-    ""
+    "But what bothers me is that it's very close to the bed..."
 
 # game/puzzles/dia3/pac_dia03.rpy:257
 translate english PAC3_SELECIONA_VELA_7565dea8:
 
     # "Pode causar um incêndio."
-    ""
+    "It could start a fire."
 
 # game/puzzles/dia3/pac_dia03.rpy:258
 translate english PAC3_SELECIONA_VELA_9a51caeb:
 
     # "Joe não leva jeito para essas coisas mesmo..."
-    ""
+    "Joe really has no knack for these things..."
 
 # game/puzzles/dia3/pac_dia03.rpy:267
 translate english PAC3_SELECIONA_VELA_c5b2a49c:
 
     # "Já investiguei a vela."
-    ""
+    "I've already examined the candle."
 

--- a/game/tl/english/puzzles/dia3/slp_dia03.rpy
+++ b/game/tl/english/puzzles/dia3/slp_dia03.rpy
@@ -4,53 +4,53 @@
 translate english SLIDER_PUZZLE_4X4_DIA03_96814bc5:
 
     # "Ao clicar em uma peça, posso deslizá-la para um espaço vazio."
-    ""
+    "By clicking a piece, I can slide it into an empty space."
 
 # game/puzzles/dia3/slp_dia03.rpy:73
 translate english SLIDER_PUZZLE_4X4_DIA03_3d5d521f:
 
     # "Preciso descobrir o que cada símbolo significa."
-    ""
+    "I need to figure out what each symbol means."
 
 # game/puzzles/dia3/slp_dia03.rpy:74
 translate english SLIDER_PUZZLE_4X4_DIA03_93e8002c:
 
     # "E posicionar as peças na ordem correta."
-    ""
+    "And place the pieces in the right order."
 
 # game/puzzles/dia3/slp_dia03.rpy:83
 translate english SLP_GAME_OVER_4X4_DIA03_61ea5bb9:
 
     # "Droga, vou tentar novamente..."
-    ""
+    "Darn, I'll try again..."
 
 # game/puzzles/dia3/slp_dia03.rpy:84
 translate english SLP_GAME_OVER_4X4_DIA03_c87a0b63:
 
     # "Acho que todas as peças representam números."
-    ""
+    "I think all the pieces represent numbers."
 
 # game/puzzles/dia3/slp_dia03.rpy:85
 translate english SLP_GAME_OVER_4X4_DIA03_ab1b801d:
 
     # "Mas parecem estar em sistemas numéricos diferentes."
-    ""
+    "But they seem to be in different number systems."
 
 # game/puzzles/dia3/slp_dia03.rpy:86
 translate english SLP_GAME_OVER_4X4_DIA03_2435bec2:
 
     # "Acho que cada peça fica na posição correspondente ao seu número..."
-    ""
+    "I think each piece goes in the position corresponding to its number..."
 
 # game/puzzles/dia3/slp_dia03.rpy:87
 translate english SLP_GAME_OVER_4X4_DIA03_603ddc28:
 
     # "Talvez se eu alinhasse as peças corretas na primeira linha e depois a primeira coluna, e seguir assim, reduzindo em quadrados menores..."
-    ""
+    "Maybe if I lined up the correct pieces in the first row and then the first column, and kept going like that, narrowing into smaller squares..."
 
 # game/puzzles/dia3/slp_dia03.rpy:88
 translate english SLP_GAME_OVER_4X4_DIA03_fe972149:
 
     # "Tenho certeza que resolverei."
-    ""
+    "I'm sure I'll solve it."
 

--- a/game/tl/english/puzzles/inventario/ide_teste.rpy
+++ b/game/tl/english/puzzles/inventario/ide_teste.rpy
@@ -4,107 +4,107 @@
 translate english IDE_ESCOLHEU_COPO_73fa3799:
 
     # "Claro, um copo com água resolve meu problema!"
-    ""
+    "Of course, a glass of water solves my problem!"
 
 # game/puzzles/inventario/ide_teste.rpy:40
 translate english IDE_ESCOLHEU_COPO_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/inventario/ide_teste.rpy:44
 translate english IDE_ESCOLHEU_COPO_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/inventario/ide_teste.rpy:63
 translate english IDE_ESCOLHEU_COOKIE_e57e4aa8:
 
     # "Olhando bem..."
-    ""
+    "Looking closely..."
 
 # game/puzzles/inventario/ide_teste.rpy:64
 translate english IDE_ESCOLHEU_COOKIE_cedf4f71:
 
     # "Parece ser um cookie de gengibre!"
-    ""
+    "It looks like a gingerbread cookie!"
 
 # game/puzzles/inventario/ide_teste.rpy:65
 translate english IDE_ESCOLHEU_COOKIE_59852622:
 
     # "Delicious Tommy!"
-    ""
+    "Delicious Tommy!"
 
 # game/puzzles/inventario/ide_teste.rpy:70
 translate english IDE_ESCOLHEU_COOKIE_3c90c5f3:
 
     # "Não sei... acho que não é isso..."
-    ""
+    "I don't know... I don't think that's it..."
 
 # game/puzzles/inventario/ide_teste.rpy:74
 translate english IDE_ESCOLHEU_COOKIE_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/inventario/ide_teste.rpy:93
 translate english IDE_ESCOLHEU_SEIJI_33f99674:
 
     # "Não está presente..."
-    ""
+    "It's not here..."
 
 # game/puzzles/inventario/ide_teste.rpy:94
 translate english IDE_ESCOLHEU_SEIJI_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/inventario/ide_teste.rpy:99
 translate english IDE_ESCOLHEU_SEIJI_33f99674_1:
 
     # "Não está presente..."
-    ""
+    "It's not here..."
 
 # game/puzzles/inventario/ide_teste.rpy:100
 translate english IDE_ESCOLHEU_SEIJI_a20cefa7_1:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/inventario/ide_teste.rpy:104
 translate english IDE_ESCOLHEU_SEIJI_29f37890:
 
     # "Já usei essa pista antes... não é isso..."
-    ""
+    "I've used this clue before... that's not it..."
 
 # game/puzzles/inventario/ide_teste.rpy:105
 translate english IDE_ESCOLHEU_SEIJI_f291dfa3:
 
     # "Além disso, não está presente..."
-    ""
+    "Besides, it's not here..."
 
 # game/puzzles/inventario/ide_teste.rpy:116
 translate english IDE_TESTE_ESCOLHE_FRASE_65bef21c:
 
     # "O que eu posso escolher pra comer?"
-    ""
+    "What can I choose to eat?"
 
 # game/puzzles/inventario/ide_teste.rpy:120
 translate english IDE_TESTE_ESCOLHE_FRASE_597999d7:
 
     # "Ok... agora tô com sede"
-    ""
+    "Okay... now I'm thirsty"
 
 # game/puzzles/inventario/ide_teste.rpy:121
 translate english IDE_TESTE_ESCOLHE_FRASE_cd0aa9a2:
 
     # "O que eu posso escolher pra beber?"
-    ""
+    "What can I choose to drink?"
 
 # game/puzzles/inventario/ide_teste.rpy:129
 translate english IDE_TESTE_ESCOLHE_FRASE_7cb26e5f:
 
     # "Muito bom, acho que agora terminei tudo!"
-    ""
+    "Very good, I think I've finished everything now!"
 

--- a/game/tl/english/puzzles/lights_out/lights_out_teste.rpy
+++ b/game/tl/english/puzzles/lights_out/lights_out_teste.rpy
@@ -4,23 +4,23 @@
 translate english LIGHTS_OUT_TEST_44394522:
 
     # "Hmmm, que interessante..."
-    ""
+    "Hmmm, how interesting..."
 
 # game/puzzles/lights_out/lights_out_teste.rpy:12
 translate english LIGHTS_OUT_TEST_8f42474c:
 
     # "Parece que temos que resolver um puzzle..."
-    ""
+    "Looks like we have to solve a puzzle..."
 
 # game/puzzles/lights_out/lights_out_teste.rpy:13
 translate english LIGHTS_OUT_TEST_d2ef1b11:
 
     # "Vamos lá!"
-    ""
+    "Let's go!"
 
 # game/puzzles/lights_out/lights_out_teste.rpy:21
 translate english FIM_LOP_TESTE_a887476b:
 
     # "Droga, vamos tentar novamente"
-    ""
+    "Darn, let's try again"
 

--- a/game/tl/english/puzzles/point_and_click/pac_prototipo.rpy
+++ b/game/tl/english/puzzles/point_and_click/pac_prototipo.rpy
@@ -4,107 +4,107 @@
 translate english PACP_SELECIONA_ESTANTE_3755b29f:
 
     # shp_side "Quer investigar essa gaveta?"
-    shp_side ""
+    shp_side "Do you want to investigate this drawer?"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:114
 translate english PACP_SELECIONA_ESTANTE_f945ca03:
 
     # drc "Será que há algum item nela?"
-    drc ""
+    drc "Could there be an item in it?"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:115
 translate english PACP_SELECIONA_ESTANTE_b99fb8e2:
 
     # drc "Olha só!"
-    drc ""
+    drc "Look at that!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:119
 translate english PACP_SELECIONA_ESTANTE_85a3834f:
 
     # "Minha barriga estava roncando agora a pouco. Este cookie pode ser útil..."
-    ""
+    "My stomach was growling just now. This cookie could be useful..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:124
 translate english PACP_SELECIONA_ESTANTE_9a89c7d1:
 
     # shp_side "Mas eu tava deixando pra mais tar..."
-    shp_side ""
+    shp_side "But I was saving it for la..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:125
 translate english PACP_SELECIONA_ESTANTE_757327b3:
 
     # drc "Delicioso!"
-    drc ""
+    drc "Delicious!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:126
 translate english PACP_SELECIONA_ESTANTE_b40f34f6:
 
     # drc "O que? o senhor disse algo?"
-    drc ""
+    drc "What? Did you say something, sir?"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:127
 translate english PACP_SELECIONA_ESTANTE_833e6371:
 
     # shp_side "Ah, deixa pra lá..."
-    shp_side ""
+    shp_side "Ah, never mind..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:129
 translate english PACP_SELECIONA_ESTANTE_598928a8:
 
     # "Acho que não há mais nada que eu possa pegar por aqui..."
-    ""
+    "I don't think there's anything else I can pick up around here..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:130
 translate english PACP_SELECIONA_ESTANTE_5f194a44:
 
     # shp_side "Ufa, ainda bem que ele não viu o burrito..."
-    shp_side ""
+    shp_side "Phew, good thing he didn't see the burrito..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:131
 translate english PACP_SELECIONA_ESTANTE_4f9a66a4:
 
     # drc "Disse alguma coisa?"
-    drc ""
+    drc "Did you say something?"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:132
 translate english PACP_SELECIONA_ESTANTE_f34fe033:
 
     # shp_side "Não, nada..."
-    shp_side ""
+    shp_side "No, nothing..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:133
 translate english PACP_SELECIONA_ESTANTE_ed846fdc:
 
     # drc "Ok..."
-    drc ""
+    drc "Okay..."
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:140
 translate english PACP_SELECIONA_VELA_ef101a85:
 
     # "É apenas uma vela comum, mas vou me lembrar dela!"
-    ""
+    "It's just an ordinary candle, but I'll remember it!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:152
 translate english PACP_SELECIONA_VELA2_ef101a85:
 
     # "É apenas uma vela comum, mas vou me lembrar dela!"
-    ""
+    "It's just an ordinary candle, but I'll remember it!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:163
 translate english PACP_SELECIONA_VELA3_ef101a85:
 
     # "É apenas uma vela comum, mas vou me lembrar dela!"
-    ""
+    "It's just an ordinary candle, but I'll remember it!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:174
 translate english PACP_SELECIONA_VELA4_ef101a85:
 
     # "É apenas uma vela comum, mas vou me lembrar dela!"
-    ""
+    "It's just an ordinary candle, but I'll remember it!"
 
 # game/puzzles/point_and_click/pac_prototipo.rpy:185
 translate english PACP_SELECIONA_VELA5_ef101a85:
 
     # "É apenas uma vela comum, mas vou me lembrar dela!"
-    ""
+    "It's just an ordinary candle, but I'll remember it!"
 

--- a/game/tl/english/puzzles/point_and_click/point_and_click_teste.rpy
+++ b/game/tl/english/puzzles/point_and_click/point_and_click_teste.rpy
@@ -4,83 +4,83 @@
 translate english SELECIONA_ESTANTE_727ed58c:
 
     # shp "Quer investigar esse criado mudo?"
-    shp ""
+    shp "Do you want to investigate this nightstand?"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:75
 translate english SELECIONA_ESTANTE_51c6bf71:
 
     # drc "Será que há algum item nele?"
-    drc ""
+    drc "Could there be an item in it?"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:76
 translate english SELECIONA_ESTANTE_b99fb8e2:
 
     # drc "Olha só!"
-    drc ""
+    drc "Look at that!"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:80
 translate english SELECIONA_ESTANTE_85a3834f:
 
     # "Minha barriga estava roncando agora a pouco. Este cookie pode ser útil..."
-    ""
+    "My stomach was growling just now. This cookie could be useful..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:85
 translate english SELECIONA_ESTANTE_0b82abb1:
 
     # shp "Mas eu tava deixando pra mais tar..."
-    shp ""
+    shp "But I was saving it for la..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:86
 translate english SELECIONA_ESTANTE_757327b3:
 
     # drc "Delicioso!"
-    drc ""
+    drc "Delicious!"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:87
 translate english SELECIONA_ESTANTE_b40f34f6:
 
     # drc "O que? o senhor disse algo?"
-    drc ""
+    drc "What? Did you say something, sir?"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:88
 translate english SELECIONA_ESTANTE_d0a0ccad:
 
     # shp "Ah, deixa pra lá..."
-    shp ""
+    shp "Ah, never mind..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:91
 translate english SELECIONA_ESTANTE_598928a8:
 
     # "Acho que não há mais nada que eu possa pegar por aqui..."
-    ""
+    "I don't think there's anything else I can pick up around here..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:93
 translate english SELECIONA_ESTANTE_647932bd:
 
     # shp "Ufa, ainda bem que ele não viu o burrito..."
-    shp ""
+    shp "Phew, good thing he didn't see the burrito..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:94
 translate english SELECIONA_ESTANTE_4f9a66a4:
 
     # drc "Disse alguma coisa?"
-    drc ""
+    drc "Did you say something?"
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:95
 translate english SELECIONA_ESTANTE_14095477:
 
     # shp "Não, nada..."
-    shp ""
+    shp "No, nothing..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:96
 translate english SELECIONA_ESTANTE_ed846fdc:
 
     # drc "Ok..."
-    drc ""
+    drc "Okay..."
 
 # game/puzzles/point_and_click/point_and_click_teste.rpy:104
 translate english SELECIONA_COPO_f2aff455:
 
     # "Estou com sede, acho que este copo pode ser útil!"
-    ""
+    "I'm thirsty, I think this glass could be useful!"
 

--- a/game/tl/english/puzzles/slider/slider_teste.rpy
+++ b/game/tl/english/puzzles/slider/slider_teste.rpy
@@ -4,17 +4,17 @@
 translate english SLIDER_TEST_44394522:
 
     # "Hmmm, que interessante..."
-    ""
+    "Hmmm, how interesting..."
 
 # game/puzzles/slider/slider_teste.rpy:14
 translate english SLIDER_TEST_8f42474c:
 
     # "Parece que temos que resolver um puzzle..."
-    ""
+    "Looks like we have to solve a puzzle..."
 
 # game/puzzles/slider/slider_teste.rpy:15
 translate english SLIDER_TEST_d2ef1b11:
 
     # "Vamos lá!"
-    ""
+    "Let's go!"
 

--- a/game/tl/english/puzzles/testes_de_telas.rpy
+++ b/game/tl/english/puzzles/testes_de_telas.rpy
@@ -4,17 +4,17 @@
 translate english FIM_PAC_TESTE_fcdf5a8b:
 
     # "Prontooo, agora vamos escolhê-los"
-    ""
+    "Doneee, now let's choose them"
 
 # game/puzzles/testes_de_telas.rpy:8
 translate english FIM_PAC_TESTE_a20cefa7:
 
     # "..."
-    ""
+    "..."
 
 # game/puzzles/testes_de_telas.rpy:9
 translate english FIM_PAC_TESTE_c67f8372:
 
     # "Bom, tô com fome véi..."
-    ""
+    "Well, I'm hungry, man..."
 

--- a/game/tl/english/screens.rpy
+++ b/game/tl/english/screens.rpy
@@ -2,6 +2,9 @@
 
 translate english strings:
 
+    old "Idioma"
+    new "Language"
+
     # game/screens.rpy:271
     old "Voltar"
     new "Back"


### PR DESCRIPTION
- Completa a tradução em tl/english: cenas do Dia 2 e Dia 3, puzzles dos Dias 2 e 3 e arquivos de teste (919 falas + 4 opções de menu). O Dia 1 e a interface (screens/options) já estavam traduzidos.
- Adiciona tela de seleção de idioma (Português/English) exibida na primeira abertura do jogo (game/lang.rpy, label splashscreen) e botões de idioma na tela de Preferências.
- Substitui o config.language fixo ("english") por escolha persistente do jogador; define config.language = None como padrão. Os textos embutidos em puzzles/notificações passam a usar is_english() (idioma em tempo de execução) no lugar de config.language.
- Traduz os termos de parentesco ([ind_X_info[2]]/[3]) em tempo de execução em CENA23, sem alterar o texto-fonte dos diálogos, preservando os ids de tradução do Ren'Py.